### PR TITLE
Fix base image name to ubuntu-16.04 based one

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -16,7 +16,7 @@
 
 # ------------------------------------------------------------------------
 
-FROM wso2/wso2base:latest
+FROM wso2/wso2base:ubuntu-16.04
 MAINTAINER dev@wso2.org
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/dockerfile/common/wso2base/Dockerfile
+++ b/dockerfile/common/wso2base/Dockerfile
@@ -16,7 +16,7 @@
 
 # ------------------------------------------------------------------------
 
-FROM ubuntu:latest
+FROM ubuntu:16.04
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/dockerfile/common/wso2base/build.sh
+++ b/dockerfile/common/wso2base/build.sh
@@ -20,7 +20,7 @@
 set -e
 
 self_path=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${self_path}/../common/scripts/base.sh"
+source "${self_path}/../scripts/base.sh"
 
 echoBold "Building docker base image..."
-docker build -t wso2/wso2base ${self_path}
+docker build -t wso2/wso2base:ubuntu-16.04 ${self_path}


### PR DESCRIPTION
## Purpose
This PR fixes the `wso2/wso2base` image name to suit the changes done in [1]. Resolves #10 

## Goals
Please refer [1].

## Approach
Please refer [1].

## User stories
Please refer [1].

## Release note
Please refer [1].

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
[1]

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04.3 LTS
Docker version: 17.05.0-ce Built: Thu May  4 22:10:54 2017
 
## Learning
N/A

[1] - https://github.com/wso2/docker-common/pull/17