### PR TITLE
Migrate WSO2 Enterprise Integrator For Integration, Broker and Business Process (BPS) use-cases with Analytics deployment to WSO2 EI version 6.2.0

### DIFF
--- a/docker-compose/integrator-broker-bps-analytics/README.md
+++ b/docker-compose/integrator-broker-bps-analytics/README.md
@@ -27,7 +27,7 @@
      Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-broker-bps-analytics` folder. 
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: <br> git checkout tags/v6.1.1.4 and continue below steps.
+     i.e. for example: <br> git checkout tags/v6.2.0.4 and continue below steps.
 
   4. Execute following Docker Compose command to start the deployment.
      ```

--- a/docker-compose/integrator-broker-bps-analytics/README.md
+++ b/docker-compose/integrator-broker-bps-analytics/README.md
@@ -27,7 +27,7 @@
      Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-broker-bps-analytics` folder. 
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: <br> git checkout tags/v6.2.0.4 and continue below steps.
+     i.e. for example: <br> git checkout tags/v6.2.0.1 and continue below steps.
 
   4. Execute following Docker Compose command to start the deployment.
      ```

--- a/docker-compose/integrator-broker-bps-analytics/analytics/conf/user-mgt.xml
+++ b/docker-compose/integrator-broker-bps-analytics/analytics/conf/user-mgt.xml
@@ -84,9 +84,9 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="PasswordHashMethod">PLAIN_TEXT</Property>
             <Property name="MultiAttributeSeparator">,</Property>
@@ -133,13 +133,13 @@
             <Property name="MemberOfAttribute">memberOf</Property>
             <Property name="BackLinksEnabled">true</Property>
             <Property name="Referral">follow</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="IsBulkImportSupported">true</Property>
@@ -150,6 +150,7 @@
             <Property name="userAccountControl">512</Property>
             <Property name="MaxUserNameListLength">100</Property>     
             <Property name="MaxRoleNameListLength">100</Property>                     
+            <Property name="MembershipAttributeRange">1500</Property>
             <Property name="kdcEnabled">false</Property>
             <Property name="defaultRealmName">WSO2.ORG</Property>
             <Property name="UserRolesCacheEnabled">true</Property>
@@ -187,13 +188,13 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">true</Property>
             <Property name="IsBulkImportSupported">true</Property>

--- a/docker-compose/integrator-broker-bps-analytics/broker/conf/broker.xml
+++ b/docker-compose/integrator-broker-bps-analytics/broker/conf/broker.xml
@@ -294,6 +294,10 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
             <!--Number of MessageDeliveryWorker threads that should be started-->
             <deliveryThreadCount>5</deliveryThreadCount>
 
+            <!-- The idle time of a delivery task. Decreasing value might effect increasing delivery when the 
+                 publisher is slow. But system load could go high -->
+            <idleTaskDelay>100</idleTaskDelay>
+
             <!-- Number of parallel threads to execute slot deletion task. Increasing this value will remove slots
                  whose messages are read/delivered to consumers/acknowledged faster reducing heap memory used by
                  server.-->

--- a/docker-compose/integrator-broker-bps-analytics/broker/conf/user-mgt.xml
+++ b/docker-compose/integrator-broker-bps-analytics/broker/conf/user-mgt.xml
@@ -84,9 +84,9 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="PasswordHashMethod">PLAIN_TEXT</Property>
             <Property name="MultiAttributeSeparator">,</Property>
@@ -133,13 +133,13 @@
             <Property name="MemberOfAttribute">memberOf</Property>
             <Property name="BackLinksEnabled">true</Property>
             <Property name="Referral">follow</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="IsBulkImportSupported">true</Property>
@@ -150,6 +150,7 @@
             <Property name="userAccountControl">512</Property>
             <Property name="MaxUserNameListLength">100</Property>     
             <Property name="MaxRoleNameListLength">100</Property>                     
+            <Property name="MembershipAttributeRange">1500</Property>
             <Property name="kdcEnabled">false</Property>
             <Property name="defaultRealmName">WSO2.ORG</Property>
             <Property name="UserRolesCacheEnabled">true</Property>
@@ -187,13 +188,13 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">true</Property>
             <Property name="IsBulkImportSupported">true</Property>

--- a/docker-compose/integrator-broker-bps-analytics/business-process/conf/carbon.xml
+++ b/docker-compose/integrator-broker-bps-analytics/business-process/conf/carbon.xml
@@ -36,7 +36,7 @@
     <!--
        Product Version
     -->
-    <Version>3.6.0</Version>
+    <Version>6.2.0</Version>
 
     <!--
        Host name or IP address of the machine hosting this server

--- a/docker-compose/integrator-broker-bps-analytics/business-process/conf/user-mgt.xml
+++ b/docker-compose/integrator-broker-bps-analytics/business-process/conf/user-mgt.xml
@@ -84,9 +84,9 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="PasswordHashMethod">PLAIN_TEXT</Property>
             <Property name="MultiAttributeSeparator">,</Property>
@@ -133,13 +133,13 @@
             <Property name="MemberOfAttribute">memberOf</Property>
             <Property name="BackLinksEnabled">true</Property>
             <Property name="Referral">follow</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="IsBulkImportSupported">true</Property>
@@ -150,6 +150,7 @@
             <Property name="userAccountControl">512</Property>
             <Property name="MaxUserNameListLength">100</Property>     
             <Property name="MaxRoleNameListLength">100</Property>                     
+            <Property name="MembershipAttributeRange">1500</Property>
             <Property name="kdcEnabled">false</Property>
             <Property name="defaultRealmName">WSO2.ORG</Property>
             <Property name="UserRolesCacheEnabled">true</Property>
@@ -187,13 +188,13 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">true</Property>
             <Property name="IsBulkImportSupported">true</Property>

--- a/docker-compose/integrator-broker-bps-analytics/docker-compose.yml
+++ b/docker-compose/integrator-broker-bps-analytics/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 10
       start_period: 20s
   wso2ei-analytics:
-    image: docker.wso2.com/wso2ei-analytics:6.1.1
+    image: docker.wso2.com/wso2ei-analytics:6.2.0
     container_name: wso2ei-analytics
     hostname: wso2ei-analytics
     ports:
@@ -37,21 +37,21 @@ services:
       start_period: 30s
     volumes:
       # mounting configurations
-      - ./analytics/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/analytics/conf/datasources/master-datasources.xml
-      - ./analytics/conf/registry.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/analytics/conf/registry.xml
-      - ./analytics/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/analytics/conf/user-mgt.xml
-      - ./analytics/conf/carbon.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/analytics/conf/carbon.xml
-      - ./analytics/conf/datasources/analytics-datasources.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/analytics/conf/datasources/analytics-datasources.xml
+      - ./analytics/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/analytics/conf/datasources/master-datasources.xml
+      - ./analytics/conf/registry.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/analytics/conf/registry.xml
+      - ./analytics/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/analytics/conf/user-mgt.xml
+      - ./analytics/conf/carbon.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/analytics/conf/carbon.xml
+      - ./analytics/conf/datasources/analytics-datasources.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/analytics/conf/datasources/analytics-datasources.xml
       # mounting keystores
-      - ./analytics/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.1.1/wso2/analytics/repository/resources/security/wso2carbon.jks
-      - ./analytics/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.1.1/wso2/analytics/repository/resources/security/client-truststore.jks
+      - ./analytics/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.2.0/wso2/analytics/repository/resources/security/wso2carbon.jks
+      - ./analytics/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.2.0/wso2/analytics/repository/resources/security/client-truststore.jks
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
     links:
       - wso2ei-mysql
   wso2ei-business-process:
-    image: docker.wso2.com/wso2ei-business-process:6.1.1
+    image: docker.wso2.com/wso2ei-business-process:6.2.0
     container_name: wso2ei-business-process
     hostname: wso2ei-business-process
     ports:
@@ -64,17 +64,17 @@ services:
       start_period: 60s
     volumes:
       # mounting configurations
-      - ./business-process/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/datasources/master-datasources.xml
-      - ./business-process/conf/datasources/bps-datasources.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/datasources/bps-datasources.xml
-      - ./business-process/conf/datasources/activiti-datasources.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/datasources/activiti-datasources.xml
-      - ./business-process/conf/etc/tasks-config.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/etc/tasks-config.xml
-      - ./business-process/conf/registry.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/registry.xml
-      - ./business-process/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/user-mgt.xml
-      - ./business-process/conf/bps.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/bps.xml
-      - ./business-process/conf/carbon.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/conf/carbon.xml
+      - ./business-process/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/datasources/master-datasources.xml
+      - ./business-process/conf/datasources/bps-datasources.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/datasources/bps-datasources.xml
+      - ./business-process/conf/datasources/activiti-datasources.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/datasources/activiti-datasources.xml
+      - ./business-process/conf/etc/tasks-config.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/etc/tasks-config.xml
+      - ./business-process/conf/registry.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/registry.xml
+      - ./business-process/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/user-mgt.xml
+      - ./business-process/conf/bps.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/bps.xml
+      - ./business-process/conf/carbon.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/conf/carbon.xml
       # mounting keystores
-      - ./business-process/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/repository/resources/security/wso2carbon.jks
-      - ./business-process/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.1.1/wso2/business-process/repository/resources/security/client-truststore.jks
+      - ./business-process/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/repository/resources/security/wso2carbon.jks
+      - ./business-process/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.2.0/wso2/business-process/repository/resources/security/client-truststore.jks
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -84,7 +84,7 @@ services:
       - wso2ei-mysql
       - wso2ei-analytics
   wso2ei-broker:
-    image: docker.wso2.com/wso2ei-broker:6.1.1
+    image: docker.wso2.com/wso2ei-broker:6.2.0
     container_name: wso2ei-broker
     hostname: wso2ei-broker
     ports:
@@ -102,14 +102,14 @@ services:
       start_period: 90s
     volumes:
       # mounting configurations
-      - ./broker/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/broker/conf/datasources/master-datasources.xml
-      - ./broker/conf/registry.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/broker/conf/registry.xml
-      - ./broker/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/broker/conf/user-mgt.xml
-      - ./broker/conf/broker.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/broker/conf/broker.xml
-      - ./broker/conf/carbon.xml:/home/wso2carbon/wso2ei-6.1.1/wso2/broker/conf/carbon.xml
+      - ./broker/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/broker/conf/datasources/master-datasources.xml
+      - ./broker/conf/registry.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/broker/conf/registry.xml
+      - ./broker/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/broker/conf/user-mgt.xml
+      - ./broker/conf/broker.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/broker/conf/broker.xml
+      - ./broker/conf/carbon.xml:/home/wso2carbon/wso2ei-6.2.0/wso2/broker/conf/carbon.xml
       # mounting keystores
-      - ./broker/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.1.1/wso2/broker/repository/resources/security/wso2carbon.jks
-      - ./broker/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.1.1/wso2/broker/repository/resources/security/client-truststore.jks
+      - ./broker/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.2.0/wso2/broker/repository/resources/security/wso2carbon.jks
+      - ./broker/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.2.0/wso2/broker/repository/resources/security/client-truststore.jks
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -122,7 +122,7 @@ services:
       - wso2ei-analytics
       - wso2ei-business-process
   wso2ei-integrator:
-    image: docker.wso2.com/wso2ei-integrator:6.1.1
+    image: docker.wso2.com/wso2ei-integrator:6.2.0
     container_name: wso2ei-integrator
     hostname: wso2ei-integrator
     ports:
@@ -137,22 +137,22 @@ services:
       start_period: 120s
     volumes:
       # mounting configurations
-      - ./integrator/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.1.1/conf/datasources/master-datasources.xml
-      - ./integrator/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.1.1/conf/user-mgt.xml
-      - ./integrator/conf/registry.xml:/home/wso2carbon/wso2ei-6.1.1/conf/registry.xml
-      - ./integrator/conf/synapse.properties:/home/wso2carbon/wso2ei-6.1.1/conf/synapse.properties
-      - ./integrator/conf/jndi.properties:/home/wso2carbon/wso2ei-6.1.1/conf/jndi.properties
-      - ./integrator/conf/carbon.xml:/home/wso2carbon/wso2ei-6.1.1/conf/carbon.xml
-      - ./integrator/conf/axis2/axis2.xml:/home/wso2carbon/wso2ei-6.1.1/conf/axis2/axis2.xml
+      - ./integrator/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2ei-6.2.0/conf/datasources/master-datasources.xml
+      - ./integrator/conf/user-mgt.xml:/home/wso2carbon/wso2ei-6.2.0/conf/user-mgt.xml
+      - ./integrator/conf/registry.xml:/home/wso2carbon/wso2ei-6.2.0/conf/registry.xml
+      - ./integrator/conf/synapse.properties:/home/wso2carbon/wso2ei-6.2.0/conf/synapse.properties
+      - ./integrator/conf/jndi.properties:/home/wso2carbon/wso2ei-6.2.0/conf/jndi.properties
+      - ./integrator/conf/carbon.xml:/home/wso2carbon/wso2ei-6.2.0/conf/carbon.xml
+      - ./integrator/conf/axis2/axis2.xml:/home/wso2carbon/wso2ei-6.2.0/conf/axis2/axis2.xml
       # mounting carbon apps
-      - ./integrator/repository/deployment/server/carbonapps:/home/wso2carbon/wso2ei-6.1.1/repository/deployment/server/carbonapps
+      - ./integrator/repository/deployment/server/carbonapps:/home/wso2carbon/wso2ei-6.2.0/repository/deployment/server/carbonapps
       # mounting analytics event publishers
-      - ./integrator/repository/deployment/server/eventpublishers:/home/wso2carbon/wso2ei-6.1.1/repository/deployment/server/eventpublishers
+      - ./integrator/repository/deployment/server/eventpublishers:/home/wso2carbon/wso2ei-6.2.0/repository/deployment/server/eventpublishers
       # mounting synapse artifacts
-      - ./integrator/repository/deployment/server/synapse-configs:/home/wso2carbon/wso2ei-6.1.1/repository/deployment/server/synapse-configs
+      - ./integrator/repository/deployment/server/synapse-configs:/home/wso2carbon/wso2ei-6.2.0/repository/deployment/server/synapse-configs
       # mounting keystores
-      - ./integrator/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.1.1/epository/resources/security/wso2carbon.jks
-      - ./integrator/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.1.1/repository/resources/security/client-truststore.jks
+      - ./integrator/repository/resources/security/wso2carbon.jks:/home/wso2carbon/wso2ei-6.2.0/epository/resources/security/wso2carbon.jks
+      - ./integrator/repository/resources/security/client-truststore.jks:/home/wso2carbon/wso2ei-6.2.0/repository/resources/security/client-truststore.jks
     depends_on:
       wso2ei-mysql:
         condition: service_healthy

--- a/docker-compose/integrator-broker-bps-analytics/integrator/conf/axis2/axis2.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/conf/axis2/axis2.xml
@@ -62,8 +62,8 @@
     <parameter name="ModulesDirectory">axis2modules</parameter>
 
     <!-- User agent and the server details to be used in the http communication -->
-    <parameter name="userAgent" locked="true">WSO2 EI 6.1.1</parameter>
-    <parameter name="server" locked="true">WSO2 EI 6.1.1</parameter>
+    <parameter name="userAgent" locked="true">WSO2 EI 6.2.0</parameter>
+    <parameter name="server" locked="true">WSO2 EI 6.2.0</parameter>
 
     <!-- During a fault, stacktrace can be sent with the fault message. The following flag -->
     <!-- will control that behaviour -->
@@ -170,7 +170,8 @@
                          class="org.apache.axis2.transport.http.SOAPMessageFormatter"/>
         <messageFormatter contentType="text/plain"
                          class="org.apache.axis2.format.PlainTextFormatter"/>
-
+        <messageFormatter contentType="application/octet-stream"
+                          class="org.wso2.carbon.relay.ExpandingMessageFormatter"/>
         <!--JSON Message Formatters-->
         <messageFormatter contentType="application/json"
                           class="org.wso2.carbon.integrator.core.json.JsonStreamFormatter"/>
@@ -210,7 +211,8 @@
                         class="org.apache.axis2.builder.MultipartFormDataBuilder"/>
         <messageBuilder contentType="text/plain"
                         class="org.apache.axis2.format.PlainTextBuilder"/>
-
+        <messageBuilder contentType="application/octet-stream"
+                        class="org.wso2.carbon.relay.BinaryRelayBuilder"/>
         <!--JSON Message Builders-->
         <messageBuilder contentType="application/json"
                         class="org.wso2.carbon.integrator.core.json.JsonStreamBuilder"/>
@@ -240,7 +242,7 @@
     <!--             Transport Ins (Listeners)             -->
     <!-- ================================================= -->
 
-    <transportReceiver name="http" class="org.apache.synapse.transport.passthru.PassThroughHttpListener">
+     <transportReceiver name="http" class="org.apache.synapse.transport.passthru.PassThroughHttpListener">
         <parameter name="port" locked="false">8280</parameter>
         <parameter name="non-blocking" locked="false">true</parameter>
         <!--parameter name="bind-address" locked="false">hostname or IP address</parameter-->
@@ -332,8 +334,8 @@
         </parameter>
     </transportReceiver-->
 
-    <!--Uncomment this and configure as appropriate for JMS transport support with WSO2 MB 2.x.x -->
-    <transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+    <!--Uncomment this and configure as appropriate for JMS transport support with WSO2 EI Broker Profile -->
+    <!--transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
         <parameter name="myTopicConnectionFactory" locked="false">
            <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
             <parameter name="java.naming.provider.url" locked="false">conf/jndi.properties</parameter>
@@ -354,7 +356,7 @@
             <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
             <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
         </parameter>
-    </transportReceiver>
+    </transportReceiver-->
 
     <!--Uncomment this for FIX transport support
     <transportReceiver name="fix" class="org.apache.synapse.transport.fix.FIXTransportListener"/>
@@ -426,8 +428,8 @@
     <!--Uncomment this local transport to use local transport in mediation flow-->
     <!--<transportSender name="local" class="org.apache.axis2.transport.local.NonBlockingLocalTransportSender"/>-->
 
-    <!-- uncomment this and configure to use connection pools for sending messages -->
-    <transportSender name="jms" class="org.apache.axis2.transport.jms.JMSSender"/>
+   <!-- uncomment this and configure to use connection pools for sending messages>
+     <transportSender name="jms" class="org.apache.axis2.transport.jms.JMSSender"/-->
 
     <!--transportSender name="vfs" class="org.apache.synapse.transport.vfs.VFSTransportSender"/-->
 

--- a/docker-compose/integrator-broker-bps-analytics/integrator/conf/carbon.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/conf/carbon.xml
@@ -36,7 +36,7 @@
     <!--
        Product Version
     -->
-    <Version>6.1.1</Version>
+    <Version>6.2.0</Version>
 
     <!--
        Host name or IP address of the machine hosting this server

--- a/docker-compose/integrator-broker-bps-analytics/integrator/conf/user-mgt.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/conf/user-mgt.xml
@@ -84,9 +84,9 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="PasswordHashMethod">PLAIN_TEXT</Property>
             <Property name="MultiAttributeSeparator">,</Property>
@@ -133,13 +133,13 @@
             <Property name="MemberOfAttribute">memberOf</Property>
             <Property name="BackLinksEnabled">true</Property>
             <Property name="Referral">follow</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">false</Property>
             <Property name="IsBulkImportSupported">true</Property>
@@ -150,6 +150,7 @@
             <Property name="userAccountControl">512</Property>
             <Property name="MaxUserNameListLength">100</Property>     
             <Property name="MaxRoleNameListLength">100</Property>                     
+            <Property name="MembershipAttributeRange">1500</Property>
             <Property name="kdcEnabled">false</Property>
             <Property name="defaultRealmName">WSO2.ORG</Property>
             <Property name="UserRolesCacheEnabled">true</Property>
@@ -187,13 +188,13 @@
             <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
             <Property name="MembershipAttribute">member</Property>
             <Property name="BackLinksEnabled">false</Property>
-            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
             <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
             <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
-            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._-|//]{3,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
             <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
             <Property name="SCIMEnabled">true</Property>
             <Property name="IsBulkImportSupported">true</Property>

--- a/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowConfigurationPublisher.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowConfigurationPublisher.xml
@@ -11,3 +11,4 @@
     <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>
+

--- a/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowConfigurationPublisher.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowConfigurationPublisher.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<eventPublisher name="MessageFlowConfigurationPublisher"
-  statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+<eventPublisher name="MessageFlowConfigurationPublisher" statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.esb.analytics.stream.ConfigEntry" version="1.0.0"/>
   <mapping customMapping="disable" type="wso2event"/>
   <to eventAdapterType="wso2event">
@@ -9,6 +8,6 @@
     <property name="publishingMode">blocking</property>
     <property name="publishTimeout">0</property>
     <property name="receiverURL">tcp://wso2ei-analytics:7612</property>
-    <property encrypted="true" name="password">aa47+5/q7d9AvOHUyYAJDXrx0Q6GQmgzIKS/hOkzp6huHrxslJJk6Oqmv2mrW159DOTfJ7Rw2nBbfGWjGiMckTFAO9p9YVF3kDDHhiyirWEJPSESSSJeBB782qnwoXEDSAjgiiUYWSRuYIfxdibXUUZr3JPSmjaxvy+EVMjjWgouMrid51UQTW50wl3C0fX03/nak4P9+GWx14T1JGAb07fKQlgK/AwYtJ8esNyiV1j0Z2jgGM9OLpqgZ9gqjsA95htzdqy2DgC/U74qfhkUKISAXUWZdGS+rCEYBFaVzAj0aPKtXmRWTrC6OTDSTVLQCKZPfcHqnU652PUQZqqKCA==</property>
+    <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>

--- a/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowStatisticsPublisher.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowStatisticsPublisher.xml
@@ -11,3 +11,4 @@
     <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>
+

--- a/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowStatisticsPublisher.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/repository/deployment/server/eventpublishers/MessageFlowStatisticsPublisher.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<eventPublisher name="MessageFlowStatisticsPublisher"
-  statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+<eventPublisher name="MessageFlowStatisticsPublisher" statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.esb.analytics.stream.FlowEntry" version="1.0.0"/>
   <mapping customMapping="disable" type="wso2event"/>
   <to eventAdapterType="wso2event">
@@ -9,6 +8,6 @@
     <property name="publishingMode">non-blocking</property>
     <property name="publishTimeout">0</property>
     <property name="receiverURL">tcp://wso2ei-analytics:7612</property>
-    <property encrypted="true" name="password">aa47+5/q7d9AvOHUyYAJDXrx0Q6GQmgzIKS/hOkzp6huHrxslJJk6Oqmv2mrW159DOTfJ7Rw2nBbfGWjGiMckTFAO9p9YVF3kDDHhiyirWEJPSESSSJeBB782qnwoXEDSAjgiiUYWSRuYIfxdibXUUZr3JPSmjaxvy+EVMjjWgouMrid51UQTW50wl3C0fX03/nak4P9+GWx14T1JGAb07fKQlgK/AwYtJ8esNyiV1j0Z2jgGM9OLpqgZ9gqjsA95htzdqy2DgC/U74qfhkUKISAXUWZdGS+rCEYBFaVzAj0aPKtXmRWTrC6OTDSTVLQCKZPfcHqnU652PUQZqqKCA==</property>
+    <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>


### PR DESCRIPTION
## Purpose
> Migrate WSO2 Enterprise Integrator For Integration, Broker and Business Process (BPS) use-cases with Analytics deployment to WSO2 EI version 6.2.0. This closes https://github.com/wso2/docker-ei/issues/46.

## Goals
> Migrate Docker Compose resources from WSO2 Enterprise Integrator version 6.1.1 to version 6.2.0.