### PR TITLE
Prepare the Docker image for Integrator profile for clustering

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -36,6 +36,8 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_DIST}
 # set jdk configurations
 ARG JDK_DIST=jdk1.8.0*
 ARG JAVA_HOME=${USER_HOME}/java
+# set temporary location for shared artifacts
+ARG SHARED=${USER_HOME}/shared
 
 # install required packages
 RUN apt-get update && \
@@ -60,6 +62,7 @@ COPY --chown=wso2carbon:wso2 ${FILES}/${JDK_DIST} ${JAVA_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST} ${WSO2_SERVER_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib
 COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/lib
+COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST}/repository/deployment/server ${SHARED}
 
 # set the user and work directory
 USER ${USER}

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -59,6 +59,7 @@ RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
 COPY --chown=wso2carbon:wso2 ${FILES}/${JDK_DIST} ${JAVA_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST} ${WSO2_SERVER_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib
+COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/lib
 
 # set the user and work directory
 USER ${USER}

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -36,8 +36,6 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_DIST}
 # set jdk configurations
 ARG JDK_DIST=jdk1.8.0*
 ARG JAVA_HOME=${USER_HOME}/java
-# set temporary location for shared artifacts
-ARG SHARED=${USER_HOME}/shared
 
 # install required packages
 RUN apt-get update && \
@@ -62,7 +60,8 @@ COPY --chown=wso2carbon:wso2 ${FILES}/${JDK_DIST} ${JAVA_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST} ${WSO2_SERVER_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib
 COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/lib
-COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST}/repository/deployment/server ${SHARED}
+# set temporary location for shared artifacts
+COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST}/repository/deployment/server ${USER_HOME}/tmp/server
 
 # set the user and work directory
 USER ${USER}

--- a/dockerfiles/integrator/init.sh
+++ b/dockerfiles/integrator/init.sh
@@ -26,6 +26,8 @@ group=wso2
 # file path variables
 volumes=${WORKING_DIRECTORY}/volumes
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
+temp_shared_artifacts=${WORKING_DIRECTORY}/shared
+original_shared_artifacts=${WSO2_SERVER_HOME}/repository/deployment/server
 
 # capture the Docker container IP from the container's /etc/hosts file
 docker_container_ip=$(awk 'END{print $1}' /etc/hosts)
@@ -35,6 +37,18 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 
 # check if the WSO2 product home exists
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# copy the backed up artifacts from ${HOME}/shared/
+# copying the initial artifacts to ${HOME}/shared/ was done in the Dockerfile
+# this is to preserve the initial artifacts in a volume mount (the mounted directory can be empty initially)
+# the artifacts will be copied to the <WSO2_SERVER_HOME>/repository/deployment/server location, before the server is started
+if test -d ${temp_shared_artifacts}; then
+    if [ -z "$(ls -A ${original_shared_artifacts}/)" ]; then
+	    # if no artifacts under <WSO2_SERVER_HOME>/repository/deployment/server/; copy them
+        echo "Copying shared server artifacts from temporary location to the original server home location..."
+        cp -vr ${temp_shared_artifacts} ${original_shared_artifacts}
+    fi
+fi
 
 # check if any changed configuration files have been mounted, using K8s ConfigMap volumes
 

--- a/dockerfiles/integrator/init.sh
+++ b/dockerfiles/integrator/init.sh
@@ -26,7 +26,7 @@ group=wso2
 # file path variables
 volumes=${WORKING_DIRECTORY}/volumes
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
-temp_shared_artifacts=${WORKING_DIRECTORY}/shared
+temp_shared_artifacts=${WORKING_DIRECTORY}/tmp/server
 original_shared_artifacts=${WSO2_SERVER_HOME}/repository/deployment/server
 
 # capture the Docker container IP from the container's /etc/hosts file
@@ -46,7 +46,7 @@ if test -d ${temp_shared_artifacts}; then
     if [ -z "$(ls -A ${original_shared_artifacts}/)" ]; then
 	    # if no artifacts under <WSO2_SERVER_HOME>/repository/deployment/server/; copy them
         echo "Copying shared server artifacts from temporary location to the original server home location..."
-        cp -vr ${temp_shared_artifacts} ${original_shared_artifacts}
+        cp -r ${temp_shared_artifacts}/* ${original_shared_artifacts}
     fi
 fi
 


### PR DESCRIPTION
## Purpose
> In this PR, Kubernetes membership scheme JAR file is prepackaged in the Docker image. Further, artifacts to be shared during clustering have been moved to a temporary location prior to packaging. This closes https://github.com/wso2/docker-ei/issues/58 and closes https://github.com/wso2/docker-ei/issues/59.

## Goals
> Prepare the Docker image for Integrator profile for clustering