### PR TITLE
Install Netcat tool required for container health checks

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -40,7 +40,8 @@ ARG JAVA_HOME=${USER_HOME}/java
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    curl && \
+    curl \
+    netcat && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \


### PR DESCRIPTION
## Purpose
> Install Netcat tool required for container health checks. This closes https://github.com/wso2/docker-ei/issues/62.

## Goals
> Install Netcat tool required for container health checks.