### PR TITLE
Prepare business process server profile Docker image for artifact sharing

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -33,6 +33,17 @@ extract into `<DOCKERFILE_HOME>/base/files`.
 [Geronimo JMS Spec](http://maven.wso2.org/nexus/content/groups/wso2-public/org/apache/geronimo/specs/wso2/geronimo-jms_1.1_spec/1.1.0.wso2v1/) JAR v1.1.0.wso2v1 and
 [Secure-vault](http://maven.wso2.org/nexus/content/groups/wso2-public/org/wso2/securevault/org.wso2.securevault/1.0.0-wso2v2/) JAR v.1.0.0-wso2v2 <br> to 
 `[docker-ei]/dockerfiles/integrator/files`. These libraries are needed for the communication between Integrator <br> and Message Broker.
+- If you intend to use the Docker images with Kubernetes clustered product deployments, download the
+[Kubernetes membership scheme](http://central.maven.org/maven2/org/wso2/carbon/kubernetes/artifacts/kubernetes-membership-scheme/1.0.5/kubernetes-membership-scheme-1.0.5.jar)
+and [dnsjava for DNS lookups](http://central.maven.org/maven2/dnsjava/dnsjava/2.1.8/dnsjava-2.1.8.jar) JAR artifacts and copy them to
+`<DOCKERFILE_HOME>/base/files` folder.
+- If you **DO NOT** intend to use the Docker images with Kubernetes clustered product deployments, comment out
+the following lines from `<DOCKERFILE_HOME>/base/Dockerfile` file.
+```
+# artifacts for Kubernetes membership scheme based clustering
+COPY --chown=wso2carbon:wso2 ${FILES}/dnsjava-*.jar ${WSO2_SERVER_HOME}/lib
+COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/dropins
+```
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products)
 in order to obtain latest bug fixes and updates for the product.
 

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -62,7 +62,7 @@ in order to obtain latest bug fixes and updates for the product.
 - For integrator,
     + `docker run -p 8280:8280 -p 8243:8243 -p 9443:9443 wso2ei-integrator:6.2.0`
 - For business process,
-    + `docker run -p 9445:9445 wso2ei-business-process:6.2.0`  
+    + `docker run -p 9445:9445 9765:9765 wso2ei-business-process:6.2.0`  
 - For broker,
     + `docker run -p 9446:9446 -p 5675:5675 ...all-port-mappings-here... wso2ei-broker:6.2.0` 
 - For msf4j,

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -60,8 +60,6 @@ COPY --chown=wso2carbon:wso2 ${FILES}/${JDK_DIST} ${JAVA_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST} ${WSO2_SERVER_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib
 COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/lib
-# set temporary location for shared artifacts
-COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST}/repository/deployment/server ${USER_HOME}/tmp/server
 
 # set the user and work directory
 USER ${USER}

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -60,7 +60,8 @@ RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
 COPY --chown=wso2carbon:wso2 ${FILES}/${JDK_DIST} ${JAVA_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST} ${WSO2_SERVER_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib
-COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/lib
+COPY --chown=wso2carbon:wso2 ${FILES}/dnsjava-*.jar ${WSO2_SERVER_HOME}/lib
+COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/dropins
 
 # set the user and work directory
 USER ${USER}

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -60,6 +60,7 @@ RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
 COPY --chown=wso2carbon:wso2 ${FILES}/${JDK_DIST} ${JAVA_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST} ${WSO2_SERVER_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib
+# artifacts for Kubernetes membership scheme based clustering
 COPY --chown=wso2carbon:wso2 ${FILES}/dnsjava-*.jar ${WSO2_SERVER_HOME}/lib
 COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/dropins
 

--- a/dockerfiles/business-process/Dockerfile
+++ b/dockerfiles/business-process/Dockerfile
@@ -22,6 +22,10 @@ FROM wso2ei-base:6.2.0
 # copy entrypoint bash script to user home
 COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 
+# set temporary location for shared artifacts
+RUN mkdir -p ${WORKING_DIRECTORY}/tmp/ && \
+    cp -r ${WSO2_SERVER_HOME}/wso2/business-process/repository/deployment/server/ ${WORKING_DIRECTORY}/tmp/
+
 # expose business-process ports
 EXPOSE 9445
 

--- a/dockerfiles/business-process/Dockerfile
+++ b/dockerfiles/business-process/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p ${WORKING_DIRECTORY}/tmp/ && \
     cp -r ${WSO2_SERVER_HOME}/wso2/business-process/repository/deployment/server/ ${WORKING_DIRECTORY}/tmp/
 
 # expose business-process ports
-EXPOSE 9445
+EXPOSE 9445 9765
 
 # set entrypoint to init script
 ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/business-process/init.sh
+++ b/dockerfiles/business-process/init.sh
@@ -45,5 +45,7 @@ test -d ${volumes} && cp -r ${volumes}/* ${WSO2_SERVER_HOME}/
 # set the Docker container IP as the `localMemberHost` under axis2.xml clustering configurations (effective only when clustering is enabled)
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/wso2/business-process/conf/axis2/axis2.xml
 
+sed -i "s#<tns:NodeId>.*<\/tns:NodeId>#<tns:NodeId>${docker_container_ip}<\/tns:NodeId>#" ${WSO2_SERVER_HOME}/wso2/business-process/conf/bps.xml
+
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/business-process.sh

--- a/dockerfiles/integrator/Dockerfile
+++ b/dockerfiles/integrator/Dockerfile
@@ -25,6 +25,9 @@ ARG FILES=./files
 # copy entrypoint bash script to user home and external libraries to product home
 COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 COPY --chown=wso2carbon:wso2 ${FILES} ${WSO2_SERVER_HOME}/lib
+# set temporary location for shared artifacts
+RUN mkdir -p ${WORKING_DIRECTORY}/tmp/ && \
+    cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/ ${WORKING_DIRECTORY}/tmp/
 
 # expose integrator ports
 EXPOSE 8280 8243 9443

--- a/dockerfiles/integrator/init.sh
+++ b/dockerfiles/integrator/init.sh
@@ -57,19 +57,16 @@ fi
 # yet, only files mounted at <WSO2_USER_HOME>/volumes will be copied into the product pack
 # hence, the files that were originally mounted using K8s ConfigMap volumes, need to be copied into <WSO2_USER_HOME>/volumes
 if test -d ${k8s_volumes}/${wso2_server_profile}/conf; then
-    # if a ConfigMap volume containing WSO2 configuration files has been mounted
     test ! -d ${volumes}/conf && mkdir -p ${volumes}/conf
     cp -rL ${k8s_volumes}/${wso2_server_profile}/conf/* ${volumes}/conf
 fi
 
 if test -d ${k8s_volumes}/${wso2_server_profile}/conf-axis2; then
-    # if a ConfigMap volume containing WSO2 axis2 configuration files has been mounted
     test ! -d ${volumes}/conf/axis2 && mkdir -p ${volumes}/conf/axis2
     cp -rL ${k8s_volumes}/${wso2_server_profile}/conf-axis2/* ${volumes}/conf/axis2
 fi
 
 if test -d ${k8s_volumes}/${wso2_server_profile}/conf-datasources; then
-    # if a ConfigMap volume containing WSO2 data source configuration files has been mounted
     test ! -d ${volumes}/conf/datasources && mkdir -p ${volumes}/conf/datasources
     cp -rL ${k8s_volumes}/${wso2_server_profile}/conf-datasources/* ${volumes}/conf/datasources
 fi


### PR DESCRIPTION
## Purpose
> Prepare business process server profile Docker image for artifact sharing during clustering. This closes https://github.com/wso2/docker-ei/issues/65.

## Goals
> Prepare business process server profile Docker image for artifact sharing during clustering.

## Approach
> When clustering the Integrator profile using container cluster management platforms, it was decided to prepackage the artifacts to be shared in a temporary location. This set of artifacts in turn would be copied to the shared volume mount (at the original location), during the deployment. The same approach has been used for business process product profile as well.