### PR TITLE
Prepare WSO2 Enterprise Integrator version 6.3.x Docker resources for clustering in Kubernetes platform

### DIFF
--- a/dockerfiles/analytics/Dockerfile
+++ b/dockerfiles/analytics/Dockerfile
@@ -22,6 +22,10 @@ FROM wso2ei-base:6.3.0
 # copy entrypoint bash script to user home
 COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 
+# set temporary location for artifacts to be persisted
+RUN mkdir -p ${WORKING_DIRECTORY}/wso2-tmp/ && \
+    cp -r ${WSO2_SERVER_HOME}/wso2/analytics/conf/analytics ${WORKING_DIRECTORY}/wso2-tmp/
+
 # expose analytics ports
 EXPOSE 9444 9612 9712 7612 7712
 

--- a/dockerfiles/analytics/init.sh
+++ b/dockerfiles/analytics/init.sh
@@ -16,12 +16,18 @@
 # ------------------------------------------------------------------------
 set -e
 
+# product profile variable
+wso2_server_profile=analytics
+
 # custom WSO2 non-root user and group variables
 user=wso2carbon
 group=wso2
 
 # file path variables
 volumes=${WORKING_DIRECTORY}/volumes
+k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
+temp_persisted_artifacts=${WORKING_DIRECTORY}/wso2-tmp/analytics
+original_persisted_artifacts=${WSO2_SERVER_HOME}/wso2/analytics/conf/analytics
 
 # capture the Docker container IP from the container's /etc/hosts file
 docker_container_ip=$(awk 'END{print $1}' /etc/hosts)
@@ -31,6 +37,48 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 
 # check if the WSO2 product home exists
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# copy the backed up artifacts from ${HOME}/wso2-tmp/analytics
+# copying the initial artifacts to ${HOME}/wso2-tmp/analytics was done in the Dockerfile
+# this is to preserve the initial artifacts in a volume mount (the mounted directory can be empty initially)
+# the artifacts will be copied to the <WSO2_SERVER_HOME>/wso2/analytics/conf/analytics location,
+# before the server is started
+if test -d ${temp_persisted_artifacts}; then
+    if [ -z "$(ls -A ${original_persisted_artifacts}/)" ]; then
+	    # if no artifacts under <WSO2_SERVER_HOME>/wso2/analytics/conf/analytics; copy them
+        echo "Copying shared server artifacts from temporary location to the original server home location..."
+        cp -R ${temp_persisted_artifacts}/* ${original_persisted_artifacts}
+    fi
+fi
+
+# check if any changed configuration files have been mounted, using K8s ConfigMap volumes
+
+# since, K8s does not support building ConfigMaps recursively from a directory, each folder has been separately
+# mounted in the form of a K8s ConfigMap volume
+# copy the mounted configuration files (through ConfigMaps) to the product pack
+if test -d ${k8s_volumes}/${wso2_server_profile}/conf; then
+    cp -RL ${k8s_volumes}/${wso2_server_profile}/conf/* ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf
+fi
+
+if test -d ${k8s_volumes}/${wso2_server_profile}/conf-analytics; then
+    cp -RL ${k8s_volumes}/${wso2_server_profile}/conf-analytics/* ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/analytics
+fi
+
+if test -d ${k8s_volumes}/${wso2_server_profile}/conf-spark-analytics; then
+    cp -RL ${k8s_volumes}/${wso2_server_profile}/conf-spark-analytics/* ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/analytics/spark
+fi
+
+if test -d ${k8s_volumes}/${wso2_server_profile}/conf-axis2; then
+    cp -RL ${k8s_volumes}/${wso2_server_profile}/conf-axis2/* ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/axis2
+fi
+
+if test -d ${k8s_volumes}/${wso2_server_profile}/conf-datasources; then
+    cp -RL ${k8s_volumes}/${wso2_server_profile}/conf-datasources/* ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/datasources
+fi
+
+if test -d ${k8s_volumes}/${wso2_server_profile}/conf-portal; then
+    cp -RL ${k8s_volumes}/${wso2_server_profile}/conf-portal/* ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/repository/deployment/server/jaggeryapps/portal/configs
+fi
 
 # copy configuration changes and external libraries
 
@@ -42,7 +90,9 @@ test -d ${volumes} && cp -r ${volumes}/* ${WSO2_SERVER_HOME}/
 # for example, setting container IP in relevant configuration files
 
 # set the Docker container IP as the `localMemberHost` under axis2.xml clustering configurations (effective only when clustering is enabled)
-sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/wso2/analytics/conf/axis2/axis2.xml
+sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/axis2/axis2.xml
+# replace host name entries (hard-coded with `integrator-with-analytics-ei-analytics`), with the Docker container IP in event-processor.xml file
+sed -i "s#<hostName>integrator-with-analytics-ei-analytics</hostName>#<hostName>${docker_container_ip}</hostName>#" ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/event-processor.xml
 
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/analytics.sh

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -61,8 +61,8 @@ COPY --chown=wso2carbon:wso2 ${FILES}/${JDK_DIST} ${JAVA_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_DIST} ${WSO2_SERVER_HOME}
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib
 # artifacts for Kubernetes membership scheme based clustering
-#COPY --chown=wso2carbon:wso2 ${FILES}/dnsjava-*.jar ${WSO2_SERVER_HOME}/lib
-#COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/dropins
+COPY --chown=wso2carbon:wso2 ${FILES}/dnsjava-*.jar ${WSO2_SERVER_HOME}/lib
+COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${WSO2_SERVER_HOME}/dropins
 
 # set the user and work directory
 USER ${USER}

--- a/dockerfiles/broker/init.sh
+++ b/dockerfiles/broker/init.sh
@@ -78,7 +78,7 @@ test -d ${volumes} && cp -R ${volumes}/* ${WSO2_SERVER_HOME}/
 # for example, setting container IP in relevant configuration files
 
 # set the Docker container IP as the `localMemberHost` under axis2.xml clustering configurations (effective only when clustering is enabled)
-sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/wso2/broker/conf/axis2/axis2.xml
+sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/axis2/axis2.xml
 # set the Docker container IP as the Apache Thrift server host IP
 sed -i "s#<thriftServerHost>.*</thriftServerHost>#<thriftServerHost>${docker_container_ip}</thriftServerHost>#" ${WSO2_SERVER_HOME}/wso2/broker/conf/broker.xml
 

--- a/dockerfiles/business-process/init.sh
+++ b/dockerfiles/business-process/init.sh
@@ -83,7 +83,7 @@ test -d ${volumes} && cp -R ${volumes}/* ${WSO2_SERVER_HOME}/
 # for example, setting container IP in relevant configuration files
 
 # set the Docker container IP as the `localMemberHost` under axis2.xml clustering configurations (effective only when clustering is enabled)
-sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/wso2/business-process/conf/axis2/axis2.xml
+sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/conf/axis2/axis2.xml
 # set the Docker container IP as the `NodeId` under bps.xml (a unique id for a cluster member)
 sed -i "s#<tns:NodeId>.*<\/tns:NodeId>#<tns:NodeId>${docker_container_ip}<\/tns:NodeId>#" ${WSO2_SERVER_HOME}/wso2/business-process/conf/bps.xml
 

--- a/dockerfiles/integrator/Dockerfile
+++ b/dockerfiles/integrator/Dockerfile
@@ -26,8 +26,8 @@ ARG FILES=./files
 COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 COPY --chown=wso2carbon:wso2 ${FILES} ${WSO2_SERVER_HOME}/lib
 # set temporary location for shared artifacts
-RUN mkdir -p ${WORKING_DIRECTORY}/tmp/ && \
-    cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/ ${WORKING_DIRECTORY}/tmp/
+RUN mkdir -p ${WORKING_DIRECTORY}/wso2-tmp/ && \
+    cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/ ${WORKING_DIRECTORY}/wso2-tmp/
 
 # expose integrator ports
 EXPOSE 8280 8243 9443 4100

--- a/dockerfiles/integrator/init.sh
+++ b/dockerfiles/integrator/init.sh
@@ -26,7 +26,7 @@ group=wso2
 # file path variables
 volumes=${WORKING_DIRECTORY}/volumes
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
-temp_shared_artifacts=${WORKING_DIRECTORY}/tmp/server
+temp_shared_artifacts=${WORKING_DIRECTORY}/wso2-tmp/server
 original_shared_artifacts=${WSO2_SERVER_HOME}/repository/deployment/server
 
 # capture the Docker container IP from the container's /etc/hosts file
@@ -66,6 +66,10 @@ fi
 
 if test -d ${k8s_volumes}/${wso2_server_profile}/conf-datasources; then
     cp -RL ${k8s_volumes}/${wso2_server_profile}/conf-datasources/* ${WSO2_SERVER_HOME}/conf/datasources
+fi
+
+if test -d ${k8s_volumes}/${wso2_server_profile}/conf-event-publishers; then
+    cp -RL ${k8s_volumes}/${wso2_server_profile}/conf-event-publishers/* ${WSO2_SERVER_HOME}/repository/deployment/server/eventpublishers
 fi
 
 # copy configuration changes and external libraries


### PR DESCRIPTION
## Purpose
> Prepare WSO2 Enterprise Integrator version 6.3.x Docker resources for clustering in Kubernetes platform. This fixes https://github.com/wso2/docker-ei/issues/73.

## Goals
> Prepare WSO2 Enterprise Integrator version 6.3.x Docker resources for clustering in Kubernetes platform.