### PR TITLE
Rename configuration mount folder in product containers

### DIFF
--- a/docker-compose/integrator-analytics/docker-compose.yml
+++ b/docker-compose/integrator-analytics/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       start_period: 30s
     volumes:
       # mounting configurations
-      - ./analytics:/home/wso2carbon/volumes/wso2/analytics
+      - ./analytics:/home/wso2carbon/wso2-server-volume/wso2/analytics
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -59,7 +59,7 @@ services:
       start_period: 60s
     volumes:
       # mounting configurations
-      - ./integrator:/home/wso2carbon/volumes/
+      - ./integrator:/home/wso2carbon/wso2-server-volume/
     depends_on:
       wso2ei-mysql:
         condition: service_healthy

--- a/docker-compose/integrator-bps-analytics/docker-compose.yml
+++ b/docker-compose/integrator-bps-analytics/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       start_period: 30s
     volumes:
       # mounting configurations
-      - ./analytics:/home/wso2carbon/volumes/wso2/analytics
+      - ./analytics:/home/wso2carbon/wso2-server-volume/wso2/analytics
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -57,7 +57,7 @@ services:
       start_period: 60s
     volumes:
       # mounting configurations
-      - ./business-process:/home/wso2carbon/volumes/wso2/business-process
+      - ./business-process:/home/wso2carbon/wso2-server-volume/wso2/business-process
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -82,7 +82,7 @@ services:
       start_period: 120s
     volumes:
       # mounting configurations
-      - ./integrator:/home/wso2carbon/volumes
+      - ./integrator:/home/wso2carbon/wso2-server-volume
     depends_on:
       wso2ei-mysql:
         condition: service_healthy

--- a/docker-compose/integrator-broker-analytics/docker-compose.yml
+++ b/docker-compose/integrator-broker-analytics/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       start_period: 30s
     volumes:
       # mounting configurations
-      - ./analytics:/home/wso2carbon/volumes/wso2/analytics
+      - ./analytics:/home/wso2carbon/wso2-server-volume/wso2/analytics
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -62,7 +62,7 @@ services:
       start_period: 60s
     volumes:
       # mounting configurations
-      - ./broker:/home/wso2carbon/volumes/wso2/broker
+      - ./broker:/home/wso2carbon/wso2-server-volume/wso2/broker
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -87,7 +87,7 @@ services:
       start_period: 90s
     volumes:
       # mounting configurations
-      - ./integrator:/home/wso2carbon/volumes
+      - ./integrator:/home/wso2carbon/wso2-server-volume
     depends_on:
       wso2ei-mysql:
         condition: service_healthy

--- a/docker-compose/integrator-broker-bps-analytics/docker-compose.yml
+++ b/docker-compose/integrator-broker-bps-analytics/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       start_period: 30s
     volumes:
       # mounting configurations
-      - ./analytics:/home/wso2carbon/volumes/wso2/analytics
+      - ./analytics:/home/wso2carbon/wso2-server-volume/wso2/analytics
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -57,7 +57,7 @@ services:
       start_period: 60s
     volumes:
       # mounting configurations
-      - ./business-process:/home/wso2carbon/volumes/wso2/business-process
+      - ./business-process:/home/wso2carbon/wso2-server-volume/wso2/business-process
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -85,7 +85,7 @@ services:
       start_period: 90s
     volumes:
       # mounting configurations
-      - ./broker:/home/wso2carbon/volumes/wso2/broker
+      - ./broker:/home/wso2carbon/wso2-server-volume/wso2/broker
     depends_on:
       wso2ei-mysql:
         condition: service_healthy
@@ -113,7 +113,7 @@ services:
       start_period: 120s
     volumes:
       # mounting configurations
-      - ./integrator:/home/wso2carbon/volumes
+      - ./integrator:/home/wso2carbon/wso2-server-volume
     depends_on:
       wso2ei-mysql:
         condition: service_healthy

--- a/dockerfiles/analytics/init.sh
+++ b/dockerfiles/analytics/init.sh
@@ -24,7 +24,7 @@ user=wso2carbon
 group=wso2
 
 # file path variables
-volumes=${WORKING_DIRECTORY}/volumes
+volumes=${WORKING_DIRECTORY}/wso2-server-volume
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
 temp_persisted_artifacts=${WORKING_DIRECTORY}/wso2-tmp/analytics
 original_persisted_artifacts=${WSO2_SERVER_HOME}/wso2/analytics/conf/analytics

--- a/dockerfiles/broker/init.sh
+++ b/dockerfiles/broker/init.sh
@@ -24,7 +24,7 @@ user=wso2carbon
 group=wso2
 
 # file path variables
-volumes=${WORKING_DIRECTORY}/volumes
+volumes=${WORKING_DIRECTORY}/wso2-server-volume
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
 temp_shared_artifacts=${WORKING_DIRECTORY}/tmp/deployment
 original_shared_artifacts=${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/repository/deployment

--- a/dockerfiles/business-process/init.sh
+++ b/dockerfiles/business-process/init.sh
@@ -24,7 +24,7 @@ user=wso2carbon
 group=wso2
 
 # file path variables
-volumes=${WORKING_DIRECTORY}/volumes
+volumes=${WORKING_DIRECTORY}/wso2-server-volume
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
 temp_shared_artifacts=${WORKING_DIRECTORY}/tmp/server
 original_shared_artifacts=${WSO2_SERVER_HOME}/wso2/${wso2_server_profile}/repository/deployment/server

--- a/dockerfiles/integrator/init.sh
+++ b/dockerfiles/integrator/init.sh
@@ -24,7 +24,7 @@ user=wso2carbon
 group=wso2
 
 # file path variables
-volumes=${WORKING_DIRECTORY}/volumes
+volumes=${WORKING_DIRECTORY}/wso2-server-volume
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
 temp_shared_artifacts=${WORKING_DIRECTORY}/wso2-tmp/server
 original_shared_artifacts=${WSO2_SERVER_HOME}/repository/deployment/server

--- a/dockerfiles/msf4j/init.sh
+++ b/dockerfiles/msf4j/init.sh
@@ -21,7 +21,7 @@ user=wso2carbon
 group=wso2
 
 # file path variables
-volumes=${WORKING_DIRECTORY}/volumes
+volumes=${WORKING_DIRECTORY}/wso2-server-volume
 
 # capture the Docker container IP from the container's /etc/hosts file
 docker_container_ip=$(awk 'END{print $1}' /etc/hosts)


### PR DESCRIPTION
## Purpose
> Rename configuration mount folder in product containers from `volumes` to `wso2-server-volume`.

## Goals
> Rename configuration mount folder in product containers with a meaningful name.