### PR TITLE
Introduce Docker resources for Micro-Integrator profile of WSO2 Enterprise Integrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 *.tar.gz
 
 # IntelliJ IDEA
-.idea
+.idea/
+
+**/files/*
 
 # For integrator-analytics
 

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -2,10 +2,11 @@
 This section defines dockerfiles and step-by-step instructions to build docker images for multiple profiles <br>
 provided by WSO2 Enterprise Integrator 6.3.0, namely : <br>
 1. Integrator
-2. Business Process
-3. Broker
-4. MSF4J
-5. Analytics
+2. Micro-Integrator
+3. Business Process
+4. Broker
+5. MSF4J
+6. Analytics
 
 ## Prerequisites
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
@@ -54,24 +55,29 @@ in order to obtain latest bug fixes and updates for the product.
         
 ##### 4. Build docker images specific to each profile.
 - For integrator, navigate to `<DOCKERFILE_HOME>/integrator` directory. <br>
-  Execute `docker build` command as shown below. 
+  Execute `docker build` command as shown below.
     + `docker build -t wso2ei-integrator:6.3.0 .`
+- For micro-integrator, navigate to `<DOCKERFILE_HOME>/micro-integrator` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2ei-micro-integrator:6.3.0 .`
 - For business process, navigate to `<DOCKERFILE_HOME>/business-process` directory. <br>
-  Execute `docker build` command as shown below. 
+  Execute `docker build` command as shown below.
     + `docker build -t wso2ei-business-process:6.3.0 .`
 - For broker, navigate to `<DOCKERFILE_HOME>/broker` directory. <br>
-  Execute `docker build` command as shown below. 
+  Execute `docker build` command as shown below.
     + `docker build -t wso2ei-broker:6.3.0 .`
 - For msf4j, navigate to `<DOCKERFILE_HOME>/msf4j` directory. <br>
-  Execute `docker build` command as shown below. 
+  Execute `docker build` command as shown below.
     + `docker build -t wso2ei-msf4j:6.3.0 .`
 - For analytics, navigate to `<DOCKERFILE_HOME>/analytics` directory. <br>
-  Execute `docker build` command as shown below. 
+  Execute `docker build` command as shown below.
     + `docker build -t wso2ei-analytics:6.3.0 .`
     
 ##### 5. Running docker images specific to each profile.
 - For integrator,
     + `docker run -p 8280:8280 -p 8243:8243 -p 9443:9443 wso2ei-integrator:6.3.0`
+- For micro-integrator,
+    + `docker run -p 8290:8290 -p 8253:8253 wso2ei-micro-integrator:6.3.0`
 - For business process,
     + `docker run -p 9445:9445 9765:9765 wso2ei-business-process:6.3.0`  
 - For broker,

--- a/dockerfiles/micro-integrator/Dockerfile
+++ b/dockerfiles/micro-integrator/Dockerfile
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2018 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set to product base image
+FROM wso2ei-base:6.3.0
+
+# copy entrypoint bash script to user home
+COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
+
+# expose micro-integrator ports
+EXPOSE 8290 8253
+
+# set entrypoint to init script
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/micro-integrator/init.sh
+++ b/dockerfiles/micro-integrator/init.sh
@@ -33,7 +33,7 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 
 # check if any changed configuration files have been mounted
 # if any file changes have been mounted, copy the WSO2 configuration files recursively
-test -d ${volumes} && cp -r ${volumes}/* ${WSO2_SERVER_HOME}/
+test -d ${volumes} && cp -rv ${volumes}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/msf4j.sh
+sh ${WSO2_SERVER_HOME}/bin/micro-integrator.sh


### PR DESCRIPTION
## Purpose
> WSO2 Enterprise Integrator version 6.3.x introduces a new Micro-Integrator profile. Docker resources associated with this profile need to be created. This fixes https://github.com/wso2/docker-ei/issues/81.

## Goals
> Docker resources for WSO2 Enterprise Integrator version 6.3.x Micro-Integrator profile.