### PR TITLE
Allow JMS transport of Integrator profile to communicate with the Broker profile

### DIFF
--- a/docker-compose/integrator-broker-analytics/integrator/conf/axis2/axis2.xml
+++ b/docker-compose/integrator-broker-analytics/integrator/conf/axis2/axis2.xml
@@ -335,7 +335,7 @@
     </transportReceiver-->
 
     <!--Uncomment this and configure as appropriate for JMS transport support with WSO2 EI Broker Profile -->
-    <!--transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+    <transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
         <parameter name="myTopicConnectionFactory" locked="false">
            <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
             <parameter name="java.naming.provider.url" locked="false">conf/jndi.properties</parameter>
@@ -356,7 +356,7 @@
             <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
             <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
         </parameter>
-    </transportReceiver-->
+    </transportReceiver>
 
     <!--Uncomment this for FIX transport support
     <transportReceiver name="fix" class="org.apache.synapse.transport.fix.FIXTransportListener"/>
@@ -428,8 +428,8 @@
     <!--Uncomment this local transport to use local transport in mediation flow-->
     <!--<transportSender name="local" class="org.apache.axis2.transport.local.NonBlockingLocalTransportSender"/>-->
 
-   <!-- uncomment this and configure to use connection pools for sending messages>
-     <transportSender name="jms" class="org.apache.axis2.transport.jms.JMSSender"/-->
+   <!-- uncomment this and configure to use connection pools for sending messages -->
+     <transportSender name="jms" class="org.apache.axis2.transport.jms.JMSSender"/>
 
     <!--transportSender name="vfs" class="org.apache.synapse.transport.vfs.VFSTransportSender"/-->
 

--- a/docker-compose/integrator-broker-bps-analytics/integrator/conf/axis2/axis2.xml
+++ b/docker-compose/integrator-broker-bps-analytics/integrator/conf/axis2/axis2.xml
@@ -335,7 +335,7 @@
     </transportReceiver-->
 
     <!--Uncomment this and configure as appropriate for JMS transport support with WSO2 EI Broker Profile -->
-    <!--transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+    <transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
         <parameter name="myTopicConnectionFactory" locked="false">
            <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
             <parameter name="java.naming.provider.url" locked="false">conf/jndi.properties</parameter>
@@ -356,7 +356,7 @@
             <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
             <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
         </parameter>
-    </transportReceiver-->
+    </transportReceiver>
 
     <!--Uncomment this for FIX transport support
     <transportReceiver name="fix" class="org.apache.synapse.transport.fix.FIXTransportListener"/>
@@ -428,8 +428,8 @@
     <!--Uncomment this local transport to use local transport in mediation flow-->
     <!--<transportSender name="local" class="org.apache.axis2.transport.local.NonBlockingLocalTransportSender"/>-->
 
-   <!-- uncomment this and configure to use connection pools for sending messages>
-     <transportSender name="jms" class="org.apache.axis2.transport.jms.JMSSender"/-->
+   <!-- uncomment this and configure to use connection pools for sending messages -->
+     <transportSender name="jms" class="org.apache.axis2.transport.jms.JMSSender"/>
 
     <!--transportSender name="vfs" class="org.apache.synapse.transport.vfs.VFSTransportSender"/-->
 


### PR DESCRIPTION
## Purpose
> Add missing configuration of allowing JMS transport of Integrator profile to communicate with the Broker profile.

## Goals
> Allow JMS transport of Integrator profile to communicate with the Broker profile