### PR TITLE
Upgrade AdoptOpenJDK version to the latest version - jdk8u212-b03

### DIFF
--- a/dockerfiles/alpine/analytics/base/Dockerfile
+++ b/dockerfiles/alpine/analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/alpine/broker/Dockerfile
+++ b/dockerfiles/alpine/broker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/alpine/business-process/Dockerfile
+++ b/dockerfiles/alpine/business-process/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/alpine/integrator/Dockerfile
+++ b/dockerfiles/alpine/integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/alpine/msf4j/Dockerfile
+++ b/dockerfiles/alpine/msf4j/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/broker/Dockerfile
+++ b/dockerfiles/ubuntu/broker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/business-process/Dockerfile
+++ b/dockerfiles/ubuntu/business-process/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/integrator/Dockerfile
+++ b/dockerfiles/ubuntu/integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/msf4j/Dockerfile
+++ b/dockerfiles/ubuntu/msf4j/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations


### PR DESCRIPTION
## Purpose
> Upgrade AdoptOpenJDK version of Alpine and Ubuntu based Docker resources to the latest version - jdk8u212-b03. CentOS based Docker resources have already been tested with the defined version. This fixes https://github.com/wso2/docker-ei/issues/121.

## Goals
> Upgrade AdoptOpenJDK version to the latest version - jdk8u212-b03