### PR TITLE
Integrate support in Docker Compose resources for users with and without WSO2 subscriptions

### DIFF
--- a/docker-compose/integrator-analytics/README.md
+++ b/docker-compose/integrator-analytics/README.md
@@ -4,10 +4,12 @@
 
 ## Prerequisites
 
- * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
+ * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and
+   [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
- * In order to run this Docker Compose setup, you will need an active [Free Trial Subscription](https://wso2.com/free-trial-subscription) 
-   from WSO2 since the referring Docker images hosted at docker.wso2.com contains the latest updates and fixes for WSO2 Enterprise Integrator. You can sign up for a Free Trial Subscription [here](https://wso2.com/free-trial-subscription). <br><br>
+ * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription. If you do not possess an active WSO2
+   subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
+   Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Analytics Dashboard and Analytics Worker
    images using [EI Dockerfiles](../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
    For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.5.0` to <br> `image: wso2ei-integrator:6.5.0`. <br><br>
@@ -16,12 +18,14 @@
 
 
   1. Clone WSO2 Enterprise Integrator Docker git repository.
+  
      ```
      git clone https://github.com/wso2/docker-ei
      ```
      > If you are to try out an already released zip of this repo, please ignore this 1st step. 
 
   2. Switch to the `docker-compose/integrator-analytics` folder.
+  
      ```
      cd docker-ei/docker-compose/integrator-analytics
      ```
@@ -29,14 +33,21 @@
      Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-analytics` folder. 
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: <br> git checkout tags/v6.4.0.1 and continue below steps.
+     i.e. for example: <br> git checkout tags/v6.5.0.1 and continue below steps.
 
-  3. Execute following Docker Compose command to start the deployment.
+  3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
+    (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
+    
+   **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
+
+  4. Execute following Docker Compose command to start the deployment.
+  
      ```
      docker-compose up
      ```
        
-  4. Access management console via a web browser.
+  5. Access management console via a web browser.
+  
      ```
      For Integrator - https://localhost:9443/carbon
      For Analytics - https://localhost:9643/portal

--- a/docker-compose/integrator-analytics/docker-compose.yml
+++ b/docker-compose/integrator-analytics/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       timeout: 60s
       retries: 5
   wso2ei-analytics-worker:
-    image: docker.wso2.com/wso2ei-analytics-worker:6.5.0
+    image: wso2/wso2ei-analytics-worker:6.5.0
     container_name: wso2ei-analytics-worker
     ports:
       - 9091:9091
@@ -32,7 +32,7 @@ services:
       mysql:
         condition: service_healthy
   wso2ei-analytics-dashboard:
-    image: docker.wso2.com/wso2ei-analytics-dashboard:6.5.0
+    image: wso2/wso2ei-analytics-dashboard:6.5.0
     container_name: wso2ei-analytics-dashboard
     ports:
       - 9643:9643
@@ -48,7 +48,7 @@ services:
     volumes:
       - ./dashboard:/home/wso2carbon/wso2-config-volume
   wso2ei-integrator:
-    image: docker.wso2.com/wso2ei-integrator:6.5.0
+    image: wso2/wso2ei-integrator:6.5.0
     container_name: wso2ei-integrator
     ports:
       - 9443:9443

--- a/docker-compose/integrator-analytics/scripts/README.md
+++ b/docker-compose/integrator-analytics/scripts/README.md
@@ -1,32 +1,32 @@
-# WSO2 Enterprise Integrator <br> For Integration and Broker Use-cases <br> With Analytics Support
-
-![alt tag](deployment-diagram.png)
+# WSO2 Enterprise Integrator <br> For Integration Use-cases With Analytics Support
 
 ## Prerequisites
 
- * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
+ * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and
+   [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription. If you do not possess an active WSO2
    subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
    Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
- * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Message Broker, Analytics Dashboard and Analytics Worker
-   images using [EI Dockerfiles](../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
-   For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.4.0` to <br> `image: wso2ei-integrator:6.4.0`. <br><br>
-   
+ * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Analytics Dashboard and Analytics Worker
+   images using [EI Dockerfiles](../../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
+   For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.5.0` to <br> `image: wso2ei-integrator:6.5.0`. <br><br>
+       
 ## How to Run
+
 
   1. Clone WSO2 Enterprise Integrator Docker git repository.
      ```
      git clone https://github.com/wso2/docker-ei
      ```
-     > If you are to try out an already released zip of this repo, please ignore this 1st step.
+     > If you are to try out an already released zip of this repo, please ignore this 1st step. 
 
-  2. Switch to `docker-compose/integrator-broker-analytics` folder.
+  2. Switch to the `docker-compose/integrator-analytics/scripts` folder.
      ```
-     cd [docker-ei]/docker-compose/integrator-broker-analytics
+     cd docker-ei/docker-compose/integrator-analytics/scripts
      ```
      > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-     Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-broker-analytics` folder. 
+     Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-analytics` folder. 
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
      i.e. for example: <br> git checkout tags/v6.5.0.1 and continue below steps.
@@ -36,14 +36,13 @@
     
    **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-  4. Execute following Docker Compose command to start the deployment.
+  4. Execute the `deploy.sh` script to start the deployment.
      ```
-     docker-compose up
+     ./deploy.sh
      ```
-
-  4. Access management console via a web browser.
+       
+  5. Access management console via a web browser.
      ```
      For Integrator - https://localhost:9443/carbon
      For Analytics - https://localhost:9643/portal
-     For Broker - https://localhost:9446/carbon
      ```

--- a/docker-compose/integrator-analytics/scripts/deploy.sh
+++ b/docker-compose/integrator-analytics/scripts/deploy.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+ECHO=`which echo`
+GREP=`which grep`
+DOCKER_CLIENT=`which docker`
+DOCKER_COMPOSE_CLIENT=`which docker-compose`
+SED=`which sed`
+TEST=`which test`
+
+# methods
+function echoBold () {
+    ${ECHO} -e $'\e[1m'"${1}"$'\e[0m'
+}
+
+read -p "Do you have a WSO2 Subscription? (Y/N)" -n 1 -r
+${ECHO}
+
+if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+    read -p "Enter Your WSO2 Username: " WSO2_SUBSCRIPTION_USERNAME
+    ${ECHO}
+    read -s -p "Enter Your WSO2 Password: " WSO2_SUBSCRIPTION_PASSWORD
+    ${ECHO}
+
+    echoBold "Logging into WSO2 Private Docker Registry (docker.wso2.com)"
+    ${DOCKER_CLIENT} login --username ${WSO2_SUBSCRIPTION_USERNAME} --password ${WSO2_SUBSCRIPTION_PASSWORD} docker.wso2.com
+
+    if ! ${SED} -i.bak -e 's|wso2/|docker.wso2.com/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the Docker image available at WSO2 Private Docker Registry (docker.wso2.com)"
+        exit 1
+    fi
+elif [[ ${REPLY} =~ ^[Nn]$ || -z "${REPLY}" ]]; then
+    if ! ${SED} -i.bak -e 's|docker.wso2.com/|wso2/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the WSO2 Docker image available at DockerHub"
+        exit 1
+    fi
+else
+    echoBold "You have entered an invalid option."
+    exit 1
+fi
+
+# remove backed up files
+${TEST} -f ../*.bak && rm ../*.bak
+
+cd ..
+
+${DOCKER_COMPOSE_CLIENT} up -d
+
+echoBold "
+To access the Management Console of WSO2 Enterprise Integrator's Integrator profile, use https://localhost:9443/carbon.
+To access the Portal of WSO2 Analytics Dashboard, use https://localhost:9643/portal.
+
+To list the created WSO2 product server containers, use \`docker ps\` Docker client command.
+For instructions to delete the created WSO2 product server setup, please see the Docker Compose FAQ (https://wso2.com/products/install/faq/#iDocker)."

--- a/docker-compose/integrator-bps-analytics/README.md
+++ b/docker-compose/integrator-bps-analytics/README.md
@@ -6,8 +6,9 @@
 
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
- * In order to run this Docker Compose setup, you will need an active [Free Trial Subscription](https://wso2.com/free-trial-subscription) 
-   from WSO2 since the referring Docker images hosted at docker.wso2.com contains the latest updates and fixes for WSO2 Enterprise Integrator. You can sign up for a Free Trial Subscription [here](https://wso2.com/free-trial-subscription). <br><br>
+ * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription. If you do not possess an active WSO2
+   subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
+   Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Business Process Server, Analytics Dashboard and Analytics Worker
    images using [EI Dockerfiles](../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
    For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.5.0` to <br> `image: wso2ei-integrator:6.5.0`. <br><br>
@@ -28,14 +29,19 @@
      Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-bps-analytics` folder. 
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: <br> git checkout tags/v6.4.0.1 and continue below steps.
+     i.e. for example: <br> git checkout tags/v6.5.0.1 and continue below steps.
 
-  3. Execute following Docker Compose command to start the deployment.
+  3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
+    (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
+    
+   **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
+
+  4. Execute following Docker Compose command to start the deployment.
      ```
      docker-compose up
      ```
 
-  4. Access management console via a web browser.
+  5. Access management console via a web browser.
      ```
      For Integrator - https://localhost:9443/carbon
      For Analytics - https://localhost:9643/portal

--- a/docker-compose/integrator-bps-analytics/docker-compose.yml
+++ b/docker-compose/integrator-bps-analytics/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
       start_period: 80s
   wso2ei-analytics-worker:
-    image: docker.wso2.com/wso2ei-analytics-worker:6.5.0
+    image: wso2/wso2ei-analytics-worker:6.5.0
     container_name: wso2ei-analytics-worker
     ports:
       - 9091:9091
@@ -37,7 +37,7 @@ services:
       mysql:
         condition: service_healthy
   wso2ei-analytics-dashboard:
-    image: docker.wso2.com/wso2ei-analytics-dashboard:6.5.0
+    image: wso2/wso2ei-analytics-dashboard:6.5.0
     container_name: wso2ei-analytics-dashboard
     ports:
       - 9643:9643
@@ -53,7 +53,7 @@ services:
     volumes:
       - ./dashboard:/home/wso2carbon/wso2-config-volume
   wso2ei-business-process:
-    image: docker.wso2.com/wso2ei-business-process:6.5.0
+    image: wso2/wso2ei-business-process:6.5.0
     container_name: wso2ei-business-process
     ports:
       - 9445:9445
@@ -74,7 +74,7 @@ services:
       wso2ei-analytics-dashboard:
         condition: service_healthy
   wso2ei-integrator:
-    image: docker.wso2.com/wso2ei-integrator:6.5.0
+    image: wso2/wso2ei-integrator:6.5.0
     container_name: wso2ei-integrator
     ports:
       - 9443:9443

--- a/docker-compose/integrator-bps-analytics/scripts/README.md
+++ b/docker-compose/integrator-bps-analytics/scripts/README.md
@@ -1,6 +1,4 @@
-# WSO2 Enterprise Integrator <br> For Integration and Broker Use-cases <br> With Analytics Support
-
-![alt tag](deployment-diagram.png)
+# WSO2 Enterprise Integrator <br> For Integration and Business Process (BPS) <br> Use-cases With Analytics Support
 
 ## Prerequisites
 
@@ -9,10 +7,10 @@
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription. If you do not possess an active WSO2
    subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
    Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
- * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Message Broker, Analytics Dashboard and Analytics Worker
-   images using [EI Dockerfiles](../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
-   For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.4.0` to <br> `image: wso2ei-integrator:6.4.0`. <br><br>
-   
+ * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Business Process Server, Analytics Dashboard and Analytics Worker
+   images using [EI Dockerfiles](../../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
+   For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.5.0` to <br> `image: wso2ei-integrator:6.5.0`. <br><br>
+  
 ## How to Run
 
   1. Clone WSO2 Enterprise Integrator Docker git repository.
@@ -21,12 +19,12 @@
      ```
      > If you are to try out an already released zip of this repo, please ignore this 1st step.
 
-  2. Switch to `docker-compose/integrator-broker-analytics` folder.
+  2. Switch to `docker-compose/integrator-bps-analytics` folder.
      ```
-     cd [docker-ei]/docker-compose/integrator-broker-analytics
+     cd [docker-ei]/docker-compose/integrator-bps-analytics
      ```
      > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-     Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-broker-analytics` folder. 
+     Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-bps-analytics` folder. 
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
      i.e. for example: <br> git checkout tags/v6.5.0.1 and continue below steps.
@@ -36,14 +34,14 @@
     
    **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-  4. Execute following Docker Compose command to start the deployment.
+  4. Execute the `deploy.sh` script to start the deployment.
      ```
-     docker-compose up
+     ./deploy.sh
      ```
 
-  4. Access management console via a web browser.
+  5. Access management console via a web browser.
      ```
      For Integrator - https://localhost:9443/carbon
      For Analytics - https://localhost:9643/portal
-     For Broker - https://localhost:9446/carbon
+     For Business Process - https://localhost:9445/carbon
      ```

--- a/docker-compose/integrator-bps-analytics/scripts/deploy.sh
+++ b/docker-compose/integrator-bps-analytics/scripts/deploy.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+ECHO=`which echo`
+GREP=`which grep`
+DOCKER_CLIENT=`which docker`
+DOCKER_COMPOSE_CLIENT=`which docker-compose`
+SED=`which sed`
+TEST=`which test`
+
+# methods
+function echoBold () {
+    ${ECHO} -e $'\e[1m'"${1}"$'\e[0m'
+}
+
+read -p "Do you have a WSO2 Subscription? (Y/N)" -n 1 -r
+${ECHO}
+
+if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+    read -p "Enter Your WSO2 Username: " WSO2_SUBSCRIPTION_USERNAME
+    ${ECHO}
+    read -s -p "Enter Your WSO2 Password: " WSO2_SUBSCRIPTION_PASSWORD
+    ${ECHO}
+
+    echoBold "Logging into WSO2 Private Docker Registry (docker.wso2.com)"
+    ${DOCKER_CLIENT} login --username ${WSO2_SUBSCRIPTION_USERNAME} --password ${WSO2_SUBSCRIPTION_PASSWORD} docker.wso2.com
+
+    if ! ${SED} -i.bak -e 's|wso2/|docker.wso2.com/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the Docker image available at WSO2 Private Docker Registry (docker.wso2.com)"
+        exit 1
+    fi
+elif [[ ${REPLY} =~ ^[Nn]$ || -z "${REPLY}" ]]; then
+    if ! ${SED} -i.bak -e 's|docker.wso2.com/|wso2/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the WSO2 Docker image available at DockerHub"
+        exit 1
+    fi
+else
+    echoBold "You have entered an invalid option."
+    exit 1
+fi
+
+# remove backed up files
+${TEST} -f ../*.bak && rm ../*.bak
+
+cd ..
+
+${DOCKER_COMPOSE_CLIENT} up -d
+
+echoBold "
+To access the Management Console of WSO2 Enterprise Integrator's Integrator profile, use https://localhost:9443/carbon.
+To access the Portal of WSO2 Analytics Dashboard, use https://localhost:9643/portal.
+To access the Management Console of WSO2 Enterprise Integrator's Business Process Server profile, use https://localhost:9445/carbon.
+
+To list the created WSO2 product server containers, use \`docker ps\` Docker client command.
+For instructions to delete the created WSO2 product server setup, please see the Docker Compose FAQ (https://wso2.com/products/install/faq/#iDocker)."

--- a/docker-compose/integrator-broker-analytics/docker-compose.yml
+++ b/docker-compose/integrator-broker-analytics/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
       start_period: 80s
   wso2ei-analytics-worker:
-    image: docker.wso2.com/wso2ei-analytics-worker:6.5.0
+    image: wso2/wso2ei-analytics-worker:6.5.0
     container_name: wso2ei-analytics-worker
     ports:
       - 9091:9091
@@ -37,7 +37,7 @@ services:
       mysql:
         condition: service_healthy
   wso2ei-analytics-dashboard:
-    image: docker.wso2.com/wso2ei-analytics-dashboard:6.5.0
+    image: wso2/wso2ei-analytics-dashboard:6.5.0
     container_name: wso2ei-analytics-dashboard
     ports:
       - 9643:9643
@@ -53,7 +53,7 @@ services:
     volumes:
       - ./dashboard:/home/wso2carbon/wso2-config-volume
   wso2ei-broker:
-    image: docker.wso2.com/wso2ei-broker:6.5.0
+    image: wso2/wso2ei-broker:6.5.0
     container_name: wso2ei-broker
     ports:
       - 9446:9446
@@ -79,7 +79,7 @@ services:
       wso2ei-analytics-dashboard:
         condition: service_healthy
   wso2ei-integrator:
-    image: docker.wso2.com/wso2ei-integrator:6.5.0
+    image: wso2/wso2ei-integrator:6.5.0
     container_name: wso2ei-integrator
     ports:
       - 9443:9443

--- a/docker-compose/integrator-broker-analytics/scripts/README.md
+++ b/docker-compose/integrator-broker-analytics/scripts/README.md
@@ -10,7 +10,7 @@
    subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
    Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Message Broker, Analytics Dashboard and Analytics Worker
-   images using [EI Dockerfiles](../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
+   images using [EI Dockerfiles](../../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
    For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.4.0` to <br> `image: wso2ei-integrator:6.4.0`. <br><br>
    
 ## How to Run
@@ -27,7 +27,7 @@
      ```
      > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
      Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-broker-analytics` folder. 
-     
+
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
      i.e. for example: <br> git checkout tags/v6.5.0.1 and continue below steps.
 
@@ -36,9 +36,9 @@
     
    **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-  4. Execute following Docker Compose command to start the deployment.
+  4. Execute the `deploy.sh` script to start the deployment.
      ```
-     docker-compose up
+     ./deploy.sh
      ```
 
   4. Access management console via a web browser.

--- a/docker-compose/integrator-broker-analytics/scripts/deploy.sh
+++ b/docker-compose/integrator-broker-analytics/scripts/deploy.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+ECHO=`which echo`
+GREP=`which grep`
+DOCKER_CLIENT=`which docker`
+DOCKER_COMPOSE_CLIENT=`which docker-compose`
+SED=`which sed`
+TEST=`which test`
+
+# methods
+function echoBold () {
+    ${ECHO} -e $'\e[1m'"${1}"$'\e[0m'
+}
+
+read -p "Do you have a WSO2 Subscription? (Y/N)" -n 1 -r
+${ECHO}
+
+if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+    read -p "Enter Your WSO2 Username: " WSO2_SUBSCRIPTION_USERNAME
+    ${ECHO}
+    read -s -p "Enter Your WSO2 Password: " WSO2_SUBSCRIPTION_PASSWORD
+    ${ECHO}
+
+    echoBold "Logging into WSO2 Private Docker Registry (docker.wso2.com)"
+    ${DOCKER_CLIENT} login --username ${WSO2_SUBSCRIPTION_USERNAME} --password ${WSO2_SUBSCRIPTION_PASSWORD} docker.wso2.com
+
+    if ! ${SED} -i.bak -e 's|wso2/|docker.wso2.com/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the Docker image available at WSO2 Private Docker Registry (docker.wso2.com)"
+        exit 1
+    fi
+elif [[ ${REPLY} =~ ^[Nn]$ || -z "${REPLY}" ]]; then
+    if ! ${SED} -i.bak -e 's|docker.wso2.com/|wso2/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the WSO2 Docker image available at DockerHub"
+        exit 1
+    fi
+else
+    echoBold "You have entered an invalid option."
+    exit 1
+fi
+
+# remove backed up files
+${TEST} -f ../*.bak && rm ../*.bak
+
+cd ..
+
+${DOCKER_COMPOSE_CLIENT} up -d
+
+echoBold "
+To access the Management Console of WSO2 Enterprise Integrator's Integrator profile, use https://localhost:9443/carbon.
+To access the Portal of WSO2 Analytics Dashboard, use https://localhost:9643/portal.
+To access the Management Console of WSO2 Enterprise Integrator's Broker profile, use https://localhost:9446/carbon.
+
+To list the created WSO2 product server containers, use \`docker ps\` Docker client command.
+For instructions to delete the created WSO2 product server setup, please see the Docker Compose FAQ (https://wso2.com/products/install/faq/#iDocker)."

--- a/docker-compose/integrator-broker-bps-analytics/README.md
+++ b/docker-compose/integrator-broker-bps-analytics/README.md
@@ -6,8 +6,9 @@
 
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
- * In order to run this Docker Compose setup, you will need an active [Free Trial Subscription](https://wso2.com/free-trial-subscription) 
-   from WSO2 since the referring Docker images hosted at docker.wso2.com contains the latest updates and fixes for WSO2 Enterprise Integrator. You can sign up for a Free Trial Subscription [here](https://wso2.com/free-trial-subscription). <br><br>
+ * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription. If you do not possess an active WSO2
+   subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
+   Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Business Process Server, Message Broker, Analytics Dashboard and Analytics Worker
    images using [EI Dockerfiles](../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
    For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.4.0` to <br> `image: wso2ei-integrator:6.4.0`. <br><br>
@@ -29,6 +30,11 @@
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
      i.e. for example: <br> git checkout tags/v6.4.0.1 and continue below steps.
+
+  3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
+    (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
+    
+   **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
   4. Execute following Docker Compose command to start the deployment.
      ```

--- a/docker-compose/integrator-broker-bps-analytics/docker-compose.yml
+++ b/docker-compose/integrator-broker-bps-analytics/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
       start_period: 80s
   wso2ei-analytics-worker:
-    image: docker.wso2.com/wso2ei-analytics-worker:6.5.0
+    image: wso2/wso2ei-analytics-worker:6.5.0
     container_name: wso2ei-analytics-worker
     ports:
       - 9091:9091
@@ -37,7 +37,7 @@ services:
       mysql:
         condition: service_healthy
   wso2ei-analytics-dashboard:
-    image: docker.wso2.com/wso2ei-analytics-dashboard:6.5.0
+    image: wso2/wso2ei-analytics-dashboard:6.5.0
     container_name: wso2ei-analytics-dashboard
     ports:
       - 9643:9643
@@ -53,7 +53,7 @@ services:
     volumes:
       - ./dashboard:/home/wso2carbon/wso2-config-volume
   wso2ei-business-process:
-    image: docker.wso2.com/wso2ei-business-process:6.5.0
+    image: wso2/wso2ei-business-process:6.5.0
     container_name: wso2ei-business-process
     ports:
       - 9445:9445
@@ -74,7 +74,7 @@ services:
       wso2ei-analytics-dashboard:
         condition: service_healthy
   wso2ei-broker:
-    image: docker.wso2.com/wso2ei-broker:6.5.0
+    image: wso2/wso2ei-broker:6.5.0
     container_name: wso2ei-broker
     hostname: wso2ei-broker
     ports:
@@ -103,7 +103,7 @@ services:
       wso2ei-business-process:
         condition: service_healthy
   wso2ei-integrator:
-    image: docker.wso2.com/wso2ei-integrator:6.5.0
+    image: wso2/wso2ei-integrator:6.5.0
     container_name: wso2ei-integrator
     ports:
       - 9443:9443

--- a/docker-compose/integrator-broker-bps-analytics/scripts/README.md
+++ b/docker-compose/integrator-broker-bps-analytics/scripts/README.md
@@ -1,6 +1,4 @@
-# WSO2 Enterprise Integrator <br> For Integration and Broker Use-cases <br> With Analytics Support
-
-![alt tag](deployment-diagram.png)
+# WSO2 Enterprise Integrator <br> For Integration, Broker and Business Process (BPS) <br> Use-cases With Analytics Support
 
 ## Prerequisites
 
@@ -9,10 +7,10 @@
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription. If you do not possess an active WSO2
    subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
    Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
- * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Message Broker, Analytics Dashboard and Analytics Worker
+ * If you wish to run the Docker Compose configuration using Docker images built locally, build the Enterprise Integrator's Integrator, Business Process Server, Message Broker, Analytics Dashboard and Analytics Worker
    images using [EI Dockerfiles](../../dockerfiles) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`.
    For example, change the line `image: docker.wso2.com/wso2ei-integrator:6.4.0` to <br> `image: wso2ei-integrator:6.4.0`. <br><br>
-   
+               
 ## How to Run
 
   1. Clone WSO2 Enterprise Integrator Docker git repository.
@@ -21,29 +19,31 @@
      ```
      > If you are to try out an already released zip of this repo, please ignore this 1st step.
 
-  2. Switch to `docker-compose/integrator-broker-analytics` folder.
+  2. Switch to `docker-compose/integrator-broker-bps-analytics` folder.
      ```
-     cd [docker-ei]/docker-compose/integrator-broker-analytics
+     cd [docker-ei]/docker-compose/integrator-broker-bps-analytics
      ```
      > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-     Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-broker-analytics` folder. 
+     Instead, extract the zip file and directly browse to `docker-ei-<released-version>/docker-compose/integrator-broker-bps-analytics` folder. 
      
      > If you are to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: <br> git checkout tags/v6.5.0.1 and continue below steps.
+     i.e. for example: <br> git checkout tags/v6.4.0.1 and continue below steps.
 
   3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
     (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
     
    **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-  4. Execute following Docker Compose command to start the deployment.
+  4. Execute the `deploy.sh` script to start the deployment.
      ```
-     docker-compose up
+     ./deploy.sh
      ```
+     
+  5. Access management console via a web browser.
 
-  4. Access management console via a web browser.
      ```
      For Integrator - https://localhost:9443/carbon
      For Analytics - https://localhost:9643/portal
+     For Business Process - https://localhost:9445/carbon
      For Broker - https://localhost:9446/carbon
      ```

--- a/docker-compose/integrator-broker-bps-analytics/scripts/deploy.sh
+++ b/docker-compose/integrator-broker-bps-analytics/scripts/deploy.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+ECHO=`which echo`
+GREP=`which grep`
+DOCKER_CLIENT=`which docker`
+DOCKER_COMPOSE_CLIENT=`which docker-compose`
+SED=`which sed`
+TEST=`which test`
+
+# methods
+function echoBold () {
+    ${ECHO} -e $'\e[1m'"${1}"$'\e[0m'
+}
+
+read -p "Do you have a WSO2 Subscription? (Y/N)" -n 1 -r
+${ECHO}
+
+if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+    read -p "Enter Your WSO2 Username: " WSO2_SUBSCRIPTION_USERNAME
+    ${ECHO}
+    read -s -p "Enter Your WSO2 Password: " WSO2_SUBSCRIPTION_PASSWORD
+    ${ECHO}
+
+    echoBold "Logging into WSO2 Private Docker Registry (docker.wso2.com)"
+    ${DOCKER_CLIENT} login --username ${WSO2_SUBSCRIPTION_USERNAME} --password ${WSO2_SUBSCRIPTION_PASSWORD} docker.wso2.com
+
+    if ! ${SED} -i.bak -e 's|wso2/|docker.wso2.com/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the Docker image available at WSO2 Private Docker Registry (docker.wso2.com)"
+        exit 1
+    fi
+elif [[ ${REPLY} =~ ^[Nn]$ || -z "${REPLY}" ]]; then
+    if ! ${SED} -i.bak -e 's|docker.wso2.com/|wso2/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the WSO2 Docker image available at DockerHub"
+        exit 1
+    fi
+else
+    echoBold "You have entered an invalid option."
+    exit 1
+fi
+
+# remove backed up files
+${TEST} -f ../*.bak && rm ../*.bak
+
+cd ..
+
+${DOCKER_COMPOSE_CLIENT} up -d
+
+echoBold "
+To access the Management Console of WSO2 Enterprise Integrator's Integrator profile, use https://localhost:9443/carbon.
+To access the Portal of WSO2 Analytics Dashboard, use https://localhost:9643/portal.
+To access the Management Console of WSO2 Enterprise Integrator's Business Process Server profile, use https://localhost:9445/carbon.
+To access the Management Console of WSO2 Enterprise Integrator's Broker profile, use https://localhost:9446/carbon.
+
+To list the created WSO2 product server containers, use \`docker ps\` Docker client command.
+For instructions to delete the created WSO2 product server setup, please see the Docker Compose FAQ (https://wso2.com/products/install/faq/#iDocker)."


### PR DESCRIPTION
## Purpose
> Integrate support in Docker Compose resources for usage of both types of users: users with and without WSO2 subscriptions. Currently, only users with WSO2 subscriptions can utilize Docker Compose resources. This fixes https://github.com/wso2/docker-ei/issues/125.

## Goals
> Integrate support in Docker Compose resources for users with and without WSO2 subscriptions