### PR TITLE
Make command input possible

### DIFF
--- a/dockerfiles/alpine/micro-integrator/docker-entrypoint.sh
+++ b/dockerfiles/alpine/micro-integrator/docker-entrypoint.sh
@@ -30,4 +30,6 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 server
-sh ${WSO2_SERVER_HOME}/bin/micro-integrator.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/micro-integrator.sh 
+
+exec "$@"


### PR DESCRIPTION
## Purpose
> The proper way to allow commands to be executed in a container is to add `exec "$@"` at the end of its `entrypoint.sh`. Without it, there is no real flexible use of this image

## Goals
> make things clean

## Approach
> Apply syntax properly [references](https://wiki.bash-hackers.org/commands/builtin/exec)

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.