### PR TITLE
[7.1.0] Update License on MOTD to WSL

### DIFF
--- a/dockerfiles/alpine/analytics-dashboard/Dockerfile
+++ b/dockerfiles/alpine/analytics-dashboard/Dockerfile
@@ -37,11 +37,11 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip
 # build argument for MOTD
 ARG MOTD='printf "\n\
- Welcome to WSO2 Docker Resources \n\
- --------------------------------- \n\
- This Docker container comprises of a WSO2 product, running with its latest GA release \n\
- which is under the Apache License, Version 2.0. \n\
- Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"'
+    Welcome to WSO2 Docker resources.\n\
+    -----------------------------------------\n\
+    This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+    which are under the End User License Agreement (EULA) 3.1.\n\
+    Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"'
 ENV ENV=${USER_HOME}"/.ashrc"
 
 # create the non-root user and group and set MOTD login message

--- a/dockerfiles/alpine/micro-integrator/Dockerfile
+++ b/dockerfiles/alpine/micro-integrator/Dockerfile
@@ -37,11 +37,11 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip
 # build argument for MOTD
 ARG MOTD='printf "\n\
- Welcome to WSO2 Docker Resources \n\
- --------------------------------- \n\
- This Docker container comprises of a WSO2 product, running with its latest GA release \n\
- which is under the Apache License, Version 2.0. \n\
- Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"'
+    Welcome to WSO2 Docker resources.\n\
+    -----------------------------------------\n\
+    This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+    which are under the End User License Agreement (EULA) 3.1.\n\
+    Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"'
 ENV ENV=${USER_HOME}"/.ashrc"
 
 # create the non-root user and group and set MOTD login message

--- a/dockerfiles/alpine/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/alpine/monitoring-dashboard/Dockerfile
@@ -37,11 +37,11 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip
 # build argument for MOTD
 ARG MOTD='printf "\n\
- Welcome to WSO2 Docker Resources \n\
- --------------------------------- \n\
- This Docker container comprises of a WSO2 product, running with its latest GA release \n\
- which is under the Apache License, Version 2.0. \n\
- Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"'
+    Welcome to WSO2 Docker resources.\n\
+    -----------------------------------------\n\
+    This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+    which are under the End User License Agreement (EULA) 3.1.\n\
+    Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"'
 ENV ENV=${USER_HOME}"/.ashrc"
 
 # create the non-root user and group and set MOTD login message

--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -37,11 +37,11 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip
 # build argument for MOTD
 ARG MOTD='printf "\n\
- Welcome to WSO2 Docker Resources \n\
- --------------------------------- \n\
- This Docker container comprises of a WSO2 product, running with its latest GA release \n\
- which is under the Apache License, Version 2.0. \n\
- Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"'
+    Welcome to WSO2 Docker resources.\n\
+    -----------------------------------------\n\
+    This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+    which are under the End User License Agreement (EULA) 3.1.\n\
+    Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"'
 ENV ENV=${USER_HOME}"/.ashrc"
 
 # create the non-root user and group and set MOTD login message

--- a/dockerfiles/centos/analytics-dashboard/Dockerfile
+++ b/dockerfiles/centos/analytics-dashboard/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/centos/micro-integrator/Dockerfile
+++ b/dockerfiles/centos/micro-integrator/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/centos/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/centos/monitoring-dashboard/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/centos/streaming-integrator/Dockerfile
+++ b/dockerfiles/centos/streaming-integrator/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/ubuntu/micro-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/micro-integrator/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -38,10 +38,10 @@ ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/relea
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
------------------------------------- \n\
-This Docker container comprises of a WSO2 product, running with its latest GA release \n\
-which is under the Apache License, Version 2.0. \n\
-Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+-----------------------------------------\n\
+This Docker container comprises of a WSO2 product, running with its latest WSO2 updates\n\
+which are under the End User License Agreement (EULA) 3.1.\n\
+Read more about EULA 3.1 here:  @ https://wso2.com/license/wso2-update/3.1/LICENSE.txt\n"
 
 # create the non-root user and group and set MOTD login message
 RUN \


### PR DESCRIPTION
## Purpose
> Since this release, WSO2 products are under [WSO2 Software License](https://wso2.com/license/wso2-update/3.1/LICENSE.txt). The license statement should be updated. 

## Goals
> Update license to WSL

## Approach
> The license statement is updated in MOTD.
