### PR TITLE
[7.1.0] Fix server starting command

### DIFF
--- a/dockerfiles/alpine/analytics-dashboard/docker-entrypoint.sh
+++ b/dockerfiles/alpine/analytics-dashboard/docker-entrypoint.sh
@@ -30,6 +30,4 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 server
-sh ${WSO2_SERVER_HOME}/bin/portal.sh
-
-exec "$@"
+sh ${WSO2_SERVER_HOME}/bin/portal.sh "$@"

--- a/dockerfiles/alpine/micro-integrator/docker-entrypoint.sh
+++ b/dockerfiles/alpine/micro-integrator/docker-entrypoint.sh
@@ -30,6 +30,4 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 server
-sh ${WSO2_SERVER_HOME}/bin/micro-integrator.sh 
-
-exec "$@"
+sh ${WSO2_SERVER_HOME}/bin/micro-integrator.sh "$@"

--- a/dockerfiles/alpine/monitoring-dashboard/docker-entrypoint.sh
+++ b/dockerfiles/alpine/monitoring-dashboard/docker-entrypoint.sh
@@ -30,6 +30,4 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 server
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
-
-exec "$@"
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"


### PR DESCRIPTION
## Purpose
> This PR fixes #229 

## Goals
> Pass CMD args to the server startup script for Alpine based images.

## Approach
> Start server startup script as `sh ${WSO2_SERVER_STRATUP_SCRIPT} "$@"`


## Test environment
> Client: Docker Engine - Community
 Version:           18.09.2
 API version:       1.39
 Go version:        go1.10.8
 Git commit:        6247962
 Built:             Sun Feb 10 04:12:39 2019
 OS/Arch:           darwin/amd64
 Experimental:      true

> Server: Docker Engine - Community
 Engine:
  Version:          18.09.2
  API version:      1.39 (minimum version 1.12)
  Go version:       go1.10.6
  Git commit:       6247962
  Built:            Sun Feb 10 04:13:06 2019
  OS/Arch:          linux/amd64
  Experimental:     false
 