### PR TITLE
[6.6.0] Update CHANGELOG for the latest release(6.6.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project 6.6.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v6.6.0.4] - 2020-11-10
+
+### Added
+- Add git release tag as a label (refer to [issue](https://github.com/wso2/docker-ei/issues/215))
+
+### Changed
+- Enable SSL verification when retrieving remote resources using wget (refer to [issue](https://github.com/wso2/docker-ei/issues/219))
+
+For detailed information on the tasks carried out during this release, please see the GitHub milestone
+[v6.6.0.4](https://github.com/wso2/docker-ei/milestone/18)
+
 ## [v6.6.0.3] - 2020-03-12
 
 ### Changed


### PR DESCRIPTION
## Purpose
> Update CHANGELOG for the latest release

## Goals
> Create release for docker-ei 6.6.0.4
