### PR TITLE
Upgrade base OS images & prepare for the 7.0.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@ All notable changes to this project `7.0.x` per each release will be documented 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [v7.0.0.4] - 2020-11-10
+## [v7.0.0.4] - 2020-11-24
 
 ### Added
 - Add git release tag as a label (refer to [issue](https://github.com/wso2/docker-ei/issues/212))
 
 ### Changed
 - Enable SSL verification when retrieving remote resources using wget (refer to [issue](https://github.com/wso2/docker-ei/issues/213))
+- Upgrade base Docker images to jdk-11.0.9_11
 
 For detailed information on the tasks carried out during this release, please see the GitHub milestone
 [v7.0.0.4](https://github.com/wso2/docker-ei/milestone/16).

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Per profile Docker resources for WSO2 Integration help you build generic Docker 
 corresponding product servers in containerized environments. Each Docker image includes the JDK, the relevant product distribution
 and a collection of utility libraries.
 
-**Change log** from previous v7.0.0.2 release: [View Here](CHANGELOG.md)
+**Change log** from previous v7.0.0.3 release: [View Here](CHANGELOG.md)

--- a/dockerfiles/alpine/micro-integrator/Dockerfile
+++ b/dockerfiles/alpine/micro-integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.0.0.4"
 

--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.7_10-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.0.0.4"
 

--- a/dockerfiles/centos/micro-integrator/Dockerfile
+++ b/dockerfiles/centos/micro-integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.7_10
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.0.0.4"
 

--- a/dockerfiles/centos/streaming-integrator/Dockerfile
+++ b/dockerfiles/centos/streaming-integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.7_10
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.0.0.4"
 

--- a/dockerfiles/ubuntu/micro-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/micro-integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.7_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.0.0.4"
 

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.7_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.0.0.4"
 


### PR DESCRIPTION
## Purpose
- Upgrade base OS images to jdk-11.0.9_11 in MI and SI
- Prepare for the 7.0.0.4 release.

Resolves https://github.com/wso2/docker-ei/issues/257