### PR TITLE
Update base image version for MI-1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project `7.1.x` per each release will be documented 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v7.1.0.4] - 2021-02-19
+### Changed
+- Upgrade the base version of images to adoptopenjdk/openjdk11:jdk-11.0.10_9
+
 ## [v7.1.0.3] - 2020-11-23
 ### Changed
 - Upgrade base Docker images to jdk-11.0.9_11

--- a/dockerfiles/alpine/analytics-dashboard/Dockerfile
+++ b/dockerfiles/alpine/analytics-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/micro-integrator/Dockerfile
+++ b/dockerfiles/alpine/micro-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/alpine/monitoring-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/analytics-dashboard/Dockerfile
+++ b/dockerfiles/centos/analytics-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.10_9
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/micro-integrator/Dockerfile
+++ b/dockerfiles/centos/micro-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.10_9
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/centos/monitoring-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.10_9
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/streaming-integrator/Dockerfile
+++ b/dockerfiles/centos/streaming-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.10_9
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
+FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/micro-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/micro-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
+FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
+FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
+FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations


### PR DESCRIPTION
## Purpose
This PR updates the base version of MI-1.2.0 docker images as below,

Ubuntu: adoptopenjdk:11.0.10_9-jdk-hotspot-focal
Alpine: adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
Centos: adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.10_9
