### PR TITLE
Update Ubuntu base images for MI-1.2.0

### DIFF
--- a/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
+FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/analytics-dashboard/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/micro-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/micro-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
+FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/micro-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/micro-integrator/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
+FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/monitoring-dashboard/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.10_9-jdk-hotspot-focal
+FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM eclipse-temurin:11.0.13_8-jdk-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.5"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v7.1.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations


### PR DESCRIPTION
## Purpose
This PR updates the Ubuntu base images to `eclipse-temurin:11.0.13_8-jdk-focal ` (openjdk 11.0.13)

tag: https://hub.docker.com/layers/eclipse-temurin/library/eclipse-temurin/11.0.13_8-jdk-focal/images/sha256-75df241f7beb7a7e18f11c713f1b4a215e360430dad39180dafcbcdef7971320?context=explore
