### PR TITLE
[MI-4.1.0] Upgrade release tag for MI 4.1.0

### DIFF
--- a/dockerfiles/alpine/micro-integrator/Dockerfile
+++ b/dockerfiles/alpine/micro-integrator/Dockerfile
@@ -61,7 +61,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.1.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.1.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations


### PR DESCRIPTION
## Purpose
> To upgrade release tag for MI 4.1.0 that introduce a version upgrade on alpine image. 
related to https://github.com/wso2-enterprise/wso2-mi-internal/issues/303.