### PR TITLE
[MI-4.2.0] Upgrade release tag for MI 4.2.0

### DIFF
--- a/dockerfiles/alpine/micro-integrator/Dockerfile
+++ b/dockerfiles/alpine/micro-integrator/Dockerfile
@@ -55,7 +55,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.2.0.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.2.0.2"
 
 # set Docker image build arguments
 # build arguments for user/group configurations


### PR DESCRIPTION
## Purpose
> Upgrade release tag for MI 4.2.0 that introduce a version upgrade on alpine image..