### PR TITLE
Upgrade SI image alpine version to 3.19.0

### DIFF
--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Alpine Docker image
-FROM alpine:3.17.2
+FROM alpine:3.19.0
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
## Purpose
This PR upgrades the alpine version to 3.19.0 of SI image.

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/5226