### PR TITLE
[4.0.x] Update ubuntu dockerfiles to get continuous upgrades (Dashboard & SI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project `4.0.x` per each release will be documented 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v4.0.0.6] - 2024-01-23
+
+### Changed
+- Update Ubuntu Dockerfiles to get continuous upgrades.
+
 ## [v4.0.0.3] - 2022-03-04
 
 ### Changed

--- a/dockerfiles/alpine/mi-dashboard/Dockerfile
+++ b/dockerfiles/alpine/mi-dashboard/Dockerfile
@@ -61,7 +61,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/mi-dashboard/Dockerfile
+++ b/dockerfiles/alpine/mi-dashboard/Dockerfile
@@ -61,7 +61,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/micro-integrator/Dockerfile
+++ b/dockerfiles/alpine/micro-integrator/Dockerfile
@@ -61,7 +61,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.5"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -61,7 +61,7 @@ RUN echo Verifying install ... \
     && echo Complete.
     
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -61,7 +61,7 @@ RUN echo Verifying install ... \
     && echo Complete.
     
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/mi-dashboard/Dockerfile
+++ b/dockerfiles/centos/mi-dashboard/Dockerfile
@@ -65,7 +65,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/mi-dashboard/Dockerfile
+++ b/dockerfiles/centos/mi-dashboard/Dockerfile
@@ -65,7 +65,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/micro-integrator/Dockerfile
+++ b/dockerfiles/centos/micro-integrator/Dockerfile
@@ -65,7 +65,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.5"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/streaming-integrator/Dockerfile
+++ b/dockerfiles/centos/streaming-integrator/Dockerfile
@@ -65,7 +65,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/streaming-integrator/Dockerfile
+++ b/dockerfiles/centos/streaming-integrator/Dockerfile
@@ -65,7 +65,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/mi-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/mi-dashboard/Dockerfile
@@ -76,7 +76,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/mi-dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/mi-dashboard/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:20.04
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # install JDK Dependencies
-RUN apt-get update \
+RUN apt-get update && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
@@ -76,7 +76,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/micro-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/micro-integrator/Dockerfile
@@ -76,7 +76,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.5"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -76,7 +76,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.6"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:20.04
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # install JDK Dependencies
-RUN apt-get update \
+RUN apt-get update && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
@@ -76,7 +76,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.0.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations


### PR DESCRIPTION
## Purpose
> This PR updates the ubuntu dockerfiles of MI dashboard and SI to get continuous upgrades and updates the required maintainer label of all docker files.

Ports https://github.com/wso2/docker-ei/pull/337