### PR TITLE
[ICP 2.x] Add changes to pack unzip utility

### DIFF
--- a/dockerfiles/alpine/integration-control-plane/Dockerfile
+++ b/dockerfiles/alpine/integration-control-plane/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.23.3
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # install dependencies
-RUN apk update && apk upgrade --no-cache && apk add --no-cache tzdata musl-locales musl-locales-lang netcat-openbsd \
+RUN apk update && apk upgrade --no-cache && apk add --no-cache tzdata musl-locales musl-locales-lang netcat-openbsd bash unzip \
     && rm -rf /var/cache/apk/*
 
 ENV JAVA_VERSION=jdk-21.0.10+7

--- a/dockerfiles/rocky/integration-control-plane/Dockerfile
+++ b/dockerfiles/rocky/integration-control-plane/Dockerfile
@@ -105,7 +105,7 @@ RUN \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
 
 # remove unnecesary packages
-RUN yum remove -y unzip wget
+RUN yum remove -y wget
 
 # set the user and work directory
 USER ${USER_ID}

--- a/dockerfiles/ubuntu/integration-control-plane/Dockerfile
+++ b/dockerfiles/ubuntu/integration-control-plane/Dockerfile
@@ -107,7 +107,7 @@ RUN \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
 
 # remove unnecesary packages
-RUN apt-get purge -y unzip wget
+RUN apt-get purge -y wget
 
 # set the user and work directory
 USER ${USER_ID}


### PR DESCRIPTION
## Purpose
> icp.sh uses unzip at runtime to read the Implementation-Version from icp-server.jar's MANIFEST.MF..

 ```
if command -v unzip >/dev/null 2>&1 && [ -f "$JAR_FILE" ]; then
        local version
        version="$(unzip -p "$JAR_FILE" META-INF/MANIFEST.MF 2>/dev/null | awk -F': ' '/^(Implementation-Version|Specification-Version):/ {gsub("\r", "", $2); print $2; exit}')"
        if [ -n "$version" ]; then
            echo "$version"
            return 0
        fi
    fi
```

