### PR TITLE
Add SI 4.4.0 Dockerfiles for Alpine, Rocky Linux 9.5, and Ubuntu 24.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [v4.4.0.0] - 2026-05-18
 ### Added
-- Added Dockerfiles for Streaming Integrator (SI) 4.4.0 on Alpine, Rocky Linux 9.5, and Ubuntu 24.04, bundling Temurin OpenJDK 25.0.2+10.
+- Added Dockerfiles for WSO2 Integrator: SI 4.4.0 on Alpine, Rocky Linux 9.5, and Ubuntu 24.04, bundling Temurin OpenJDK 25.0.2+10.
 
 ## [v4.2.0.8] - 2025-02-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project `4.4.x` per each release will be documented 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v4.4.0.0] - 2026-05-18
+### Added
+- Added Dockerfiles for Streaming Integrator (SI) 4.4.0 on Alpine, Rocky Linux 9.5, and Ubuntu 24.04, bundling Temurin OpenJDK 25.0.2+10.
+
 ## [v4.2.0.8] - 2025-02-20
 ### Changed
 - Updated OS and JDK versions in micro-integrator Dockerfiles for Alpine, Rocky and Ubuntu for MI 4.4.0 release.

--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -1,0 +1,119 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2026 WSO2, LLC. (https://www.wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set base Docker image to Alpine Docker image
+FROM alpine:3.21.3
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# update the package list and upgrade installed packages
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache tzdata musl-locales musl-locales-lang netcat-openbsd \
+    && rm -rf /var/cache/apk/*
+
+ENV JAVA_VERSION=jdk-25.0.2+10
+
+# install Temurin OpenJDK 25
+RUN set -eux; \
+    ARCH="$(apk --print-arch)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+         ESUM='961f13ba0ee1e18c41c50ab642361e4283dee5e7947a48ed6a72c8a661d0cca0'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_x64_alpine-linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       aarch64|arm64) \
+         ESUM='e8d928fb018eabb31a148ebadaa5a5ec69273e6562afede21c426960a6a67143'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_aarch64_alpine-linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+	  wget -O /tmp/openjdk.tar.gz ${BINARY_URL}; \
+	  echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+	  mkdir -p /opt/java/openjdk; \
+	  tar --extract \
+	      --file /tmp/openjdk.tar.gz \
+	      --directory /opt/java/openjdk \
+	      --strip-components 1 \
+	      --no-same-owner \
+	  ; \
+    rm -rf /tmp/openjdk.tar.gz;
+
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:$PATH"
+
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.4.0.0"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=10802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=10802
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2si
+ARG WSO2_SERVER_VERSION=4.4.0
+ARG WSO2_SERVER_REPOSITORY=streaming-integrator
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+ARG WSO2_SERVER_DIST_URL=<SI_DIST_URL>
+# build argument for MOTD
+ARG MOTD='printf "\n\
+ Welcome to WSO2 Docker Resources \n\
+ --------------------------------- \n\
+ This Docker container comprises of a WSO2 product, running with its latest GA release \n\
+ which is under the Apache License, Version 2.0. \n\
+ Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"'
+ENV ENV=${USER_HOME}"/.ashrc"
+
+# create the non-root user and group and set MOTD login message
+RUN \
+    addgroup -S -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && adduser -S -u ${USER_ID} -h ${USER_HOME} -G ${USER_GROUP} ${USER} \
+    && echo ${MOTD} > "${ENV}"
+
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+
+# add the WSO2 product distribution to user's home directory
+RUN \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER}.zip \
+    && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
+
+# remove unnecesary packages
+RUN apk del netcat-openbsd
+
+# set the user and work directory
+USER ${USER_ID}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
+
+# expose server ports
+EXPOSE 9711 9611 7711 7611 9090 9443
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/alpine/streaming-integrator/Dockerfile
+++ b/dockerfiles/alpine/streaming-integrator/Dockerfile
@@ -101,7 +101,7 @@ RUN \
     && rm -f ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
 
-# remove unnecesary packages
+# remove unnecessary packages
 RUN apk del netcat-openbsd
 
 # set the user and work directory

--- a/dockerfiles/alpine/streaming-integrator/README.md
+++ b/dockerfiles/alpine/streaming-integrator/README.md
@@ -1,6 +1,6 @@
-# Dockerfile for WSO2 Streaming Integrator
+# Dockerfile for WSO2 Integrator: SI
 
-This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 Streaming Integrator 4.4.0.
+This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 Integrator: SI 4.4.0.
 
 ## Prerequisites
 
@@ -54,7 +54,7 @@ chmod o+r <SOURCE_CONFIGS>/server/deployment.yaml
 
 ```
 docker run -it \
--p 9445:9445 \
+-p 9444:9444 \
 --volume <SOURCE_CONFIGS>/server/deployment.yaml:<TARGET_CONFIGS>/server/deployment.yaml \
 wso2si:4.4.0-alpine
 ```

--- a/dockerfiles/alpine/streaming-integrator/README.md
+++ b/dockerfiles/alpine/streaming-integrator/README.md
@@ -1,0 +1,72 @@
+# Dockerfile for WSO2 Streaming Integrator
+
+This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 Streaming Integrator 4.4.0.
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) v17.09.0 or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-ei.git
+```
+
+>The local copy of the `dockerfiles/alpine/streaming-integrator` directory will be referred to as `SI_DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Build the Docker image.
+
+- Download wso2si-4.4.0.zip from [here](https://wso2.com/integration/streaming-integrator/)
+- Host the product pack using a webserver.
+- Navigate to `<SI_DOCKERFILE_HOME>` directory. <br>
+- Change <SI_DIST_URL> in Dockerfile to the URL of the product pack.
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2si:4.4.0-alpine .`
+
+> By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
+
+##### 3. Running the Docker image.
+
+- `docker run -it -p 9443:9443 wso2si:4.4.0-alpine`
+  
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.yaml` is as follows:
+
+##### 1. Stop the SI container if it's already running.
+
+In the SI product distribution, `deployment.yaml` configuration file can be found at `<DISTRIBUTION_HOME>/conf/server/`.
+Copy the file to some suitable location of the host machine, referred to as `<SOURCE_CONFIGS>/server/deployment.yaml` and
+increase the offset value under ports by 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/server/deployment.yaml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/server/deployment.yaml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run -it \
+-p 9445:9445 \
+--volume <SOURCE_CONFIGS>/server/deployment.yaml:<TARGET_CONFIGS>/server/deployment.yaml \
+wso2si:4.4.0-alpine
+```
+
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2si-4.4.0/conf folder of the container.
+
+## WSO2 Private Docker images
+
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/alpine/streaming-integrator/docker-entrypoint.sh
+++ b/dockerfiles/alpine/streaming-integrator/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# ------------------------------------------------------------------------
+# Copyright 2026 WSO2, LLC. (https://www.wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+# volume mounts
+config_volume=${WORKING_DIRECTORY}/wso2-config-volume
+artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+
+# check if the WSO2 non-root user home exists
+test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+# check if the WSO2 product home exists
+test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# copy any configuration changes mounted to config_volume
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+# copy any artifact changes mounted to artifact_volume
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+
+# start WSO2 server
+sh ${WSO2_SERVER_HOME}/bin/server.sh "$@"

--- a/dockerfiles/alpine/streaming-integrator/docker-entrypoint.sh
+++ b/dockerfiles/alpine/streaming-integrator/docker-entrypoint.sh
@@ -28,9 +28,9 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [ -n "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [ -n "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 server
 sh ${WSO2_SERVER_HOME}/bin/server.sh "$@"

--- a/dockerfiles/rocky/streaming-integrator/Dockerfile
+++ b/dockerfiles/rocky/streaming-integrator/Dockerfile
@@ -99,7 +99,7 @@ RUN \
     && rm -f ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
 
-# remove unnecesary packages
+# remove unnecessary packages
 RUN yum remove -y nc unzip wget
 
 # set the user and work directory

--- a/dockerfiles/rocky/streaming-integrator/Dockerfile
+++ b/dockerfiles/rocky/streaming-integrator/Dockerfile
@@ -1,0 +1,117 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2026 WSO2, LLC. (https://www.wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set base Docker image to Rocky Docker image
+FROM rockylinux/rockylinux:9.5
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# install JDK Dependencies
+RUN yum -y update && yum install -y tzdata openssl ca-certificates fontconfig gzip tar nc unzip wget \
+    && yum clean all
+
+ENV JAVA_VERSION=jdk-25.0.2+10
+
+# install Temurin OpenJDK 25
+RUN set -eux; \
+    ARCH="$(objdump="$(command -v objdump)" && objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='a9d73e711d967dc44896d4f430f73a68fd33590dabc29a7f2fb9f593425b854c'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       ppc64el|powerpc:common64) \
+         ESUM='b262b735b215173003766da36588d5f717dceada0286db41b439f93fb2ada468'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_ppc64le_linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       amd64|i386:x86-64) \
+         ESUM='987387933b64b9833846dee373b640440d3e1fd48a04804ec01a6dbf718e8ab8'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_x64_linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/openjdk; \
+    cd /opt/java/openjdk; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    rm -rf /tmp/openjdk.tar.gz;
+
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:$PATH"
+
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.4.0.0"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=10802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=10802
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2si
+ARG WSO2_SERVER_VERSION=4.4.0
+ARG WSO2_SERVER_REPOSITORY=streaming-integrator
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+ARG WSO2_SERVER_DIST_URL=<SI_DIST_URL>
+# build argument for MOTD
+ARG MOTD="\n\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+This Docker container comprises of a WSO2 product, running with its latest GA release \n\
+which is under the Apache License, Version 2.0. \n\
+Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+
+# create the non-root user and group and set MOTD login message
+RUN \
+    groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
+    && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
+
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+
+# add the WSO2 product distribution to user's home directory
+RUN \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER}.zip \
+    && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
+
+# remove unnecesary packages
+RUN yum remove -y nc unzip wget
+
+# set the user and work directory
+USER ${USER_ID}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
+
+# expose server ports
+EXPOSE 9711 9611 7711 7611 9090 9443
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/rocky/streaming-integrator/README.md
+++ b/dockerfiles/rocky/streaming-integrator/README.md
@@ -1,0 +1,72 @@
+# Dockerfile for WSO2 Streaming Integrator
+
+This section defines the step-by-step instructions to build an [RockyLinux](https://hub.docker.com/_/rockylinux) Linux based Docker image for WSO2 Streaming Integrator 4.4.0.
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) v17.09.0 or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-ei.git
+```
+
+>The local copy of the `dockerfiles/rocky/streaming-integrator` directory will be referred to as `SI_DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Build the Docker image.
+
+- Download wso2si-4.4.0.zip from [here](https://wso2.com/integration/streaming-integrator/)
+- Host the product pack using a webserver.
+- Navigate to `<SI_DOCKERFILE_HOME>` directory. <br>
+- Change <SI_DIST_URL> in Dockerfile to the URL of the product pack.
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2si:4.4.0-rocky .`
+
+> By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
+
+##### 3. Running the Docker image.
+
+- `docker run -it -p 9443:9443 wso2si:4.4.0-rocky`
+  
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.yaml` is as follows:
+
+##### 1. Stop the SI container if it's already running.
+
+In the SI product distribution, `deployment.yaml` configuration file can be found at `<DISTRIBUTION_HOME>/conf/server/`.
+Copy the file to some suitable location of the host machine, referred to as `<SOURCE_CONFIGS>/server/deployment.yaml` and
+increase the offset value under ports by 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/server/deployment.yaml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/server/deployment.yaml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run -it \
+-p 9445:9445 \
+--volume <SOURCE_CONFIGS>/server/deployment.yaml:<TARGET_CONFIGS>/server/deployment.yaml \
+wso2si:4.4.0-rocky
+```
+
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2si-4.4.0/conf folder of the container.
+
+## WSO2 Private Docker images
+
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/rocky/streaming-integrator/README.md
+++ b/dockerfiles/rocky/streaming-integrator/README.md
@@ -1,6 +1,6 @@
-# Dockerfile for WSO2 Streaming Integrator
+# Dockerfile for WSO2 Integrator: SI
 
-This section defines the step-by-step instructions to build an [RockyLinux](https://hub.docker.com/_/rockylinux) Linux based Docker image for WSO2 Streaming Integrator 4.4.0.
+This section defines the step-by-step instructions to build a [Rocky Linux](https://hub.docker.com/_/rockylinux) based Docker image for WSO2 Integrator: SI 4.4.0.
 
 ## Prerequisites
 
@@ -54,7 +54,7 @@ chmod o+r <SOURCE_CONFIGS>/server/deployment.yaml
 
 ```
 docker run -it \
--p 9445:9445 \
+-p 9444:9444 \
 --volume <SOURCE_CONFIGS>/server/deployment.yaml:<TARGET_CONFIGS>/server/deployment.yaml \
 wso2si:4.4.0-rocky
 ```

--- a/dockerfiles/rocky/streaming-integrator/docker-entrypoint.sh
+++ b/dockerfiles/rocky/streaming-integrator/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+# Copyright 2026 WSO2, LLC. (https://www.wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+# volume mounts
+config_volume=${WORKING_DIRECTORY}/wso2-config-volume
+artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+
+# check if the WSO2 non-root user home exists
+test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+# check if the WSO2 product home exists
+test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# copy any configuration changes mounted to config_volume
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+# copy any artifact changes mounted to artifact_volume
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+
+# start WSO2 server
+sh ${WSO2_SERVER_HOME}/bin/server.sh "$@"

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -106,7 +106,7 @@ RUN \
     && rm -f ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
 
-# remove unnecesary packages
+# remove unnecessary packages
 RUN apt-get purge -y netcat-traditional unzip wget
 
 # set the user and work directory

--- a/dockerfiles/ubuntu/streaming-integrator/Dockerfile
+++ b/dockerfiles/ubuntu/streaming-integrator/Dockerfile
@@ -1,0 +1,124 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2026 WSO2, LLC. (https://www.wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set base Docker image to Ubuntu Docker image
+FROM ubuntu:24.04
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# install dependencies
+RUN apt-get update && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 netcat-traditional unzip wget \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_VERSION=jdk-25.0.2+10
+
+# install Temurin OpenJDK 25
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='a9d73e711d967dc44896d4f430f73a68fd33590dabc29a7f2fb9f593425b854c'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       ppc64el|powerpc:common64) \
+         ESUM='b262b735b215173003766da36588d5f717dceada0286db41b439f93fb2ada468'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_ppc64le_linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       s390x|s390:64-bit) \
+         ESUM='15e5cbcadcf3d43623c31b825063cdc2817b9f1ba840b51dc6ef70e5d33c84e3'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_s390x_linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       amd64|i386:x86-64) \
+         ESUM='987387933b64b9833846dee373b640440d3e1fd48a04804ec01a6dbf718e8ab8'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_x64_linux_hotspot_25.0.2_10.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/openjdk; \
+    cd /opt/java/openjdk; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    rm -rf /tmp/openjdk.tar.gz;
+
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:$PATH"
+
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-ei/releases/tag/v4.4.0.0"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=10802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=10802
+ARG USER_HOME=/home/${USER}
+# build arguments for WSO2 product installation
+ARG WSO2_SERVER_NAME=wso2si
+ARG WSO2_SERVER_VERSION=4.4.0
+ARG WSO2_SERVER_REPOSITORY=streaming-integrator
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+ARG WSO2_SERVER_DIST_URL=<SI_DIST_URL>
+# build argument for MOTD
+ARG MOTD="\n\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+This Docker container comprises of a WSO2 product, running with its latest GA release \n\
+which is under the Apache License, Version 2.0. \n\
+Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+
+# create the non-root user and group and set MOTD login message
+RUN \
+    groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
+    && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
+
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+
+# add the WSO2 product distribution to user's home directory
+RUN \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER}.zip \
+    && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME}
+
+# remove unnecesary packages
+RUN apt-get purge -y netcat-traditional unzip wget
+
+# set the user and work directory
+USER ${USER_ID}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
+
+# expose server ports
+EXPOSE 9711 9611 7711 7611 9090 9443
+
+# initiate container and start WSO2 Carbon server
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/ubuntu/streaming-integrator/README.md
+++ b/dockerfiles/ubuntu/streaming-integrator/README.md
@@ -1,0 +1,73 @@
+# Dockerfile for WSO2 Streaming Integrator
+
+This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image
+for WSO2 Streaming Integrator 4.4.0.
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) v17.09.0 or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-ei.git
+```
+
+>The local copy of the `dockerfiles/ubuntu/streaming-integrator` directory will be referred to as `SI_DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Build the Docker image.
+
+- Download wso2si-4.4.0.zip from [here](https://wso2.com/integration/streaming-integrator/)
+- Host the product pack using a webserver.
+- Navigate to `<SI_DOCKERFILE_HOME>` directory. <br>
+- Change <SI_DIST_URL> in Dockerfile to the URL of the product pack.
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2si:4.4.0 .`
+
+> By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
+
+##### 3. Running the Docker image.
+
+- `docker run -it -p 9443:9443 wso2si:4.4.0`
+  
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.yaml` is as follows:
+
+##### 1. Stop the SI container if it's already running.
+
+In SI product distribution, `deployment.yaml` configuration file can be found at `<DISTRIBUTION_HOME>/conf/server`.
+Copy the file to some suitable location of the host machine, referred to as `<SOURCE_CONFIGS>/server/deployment.yaml` and
+increase the offset value under ports by 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/server/deployment.yaml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/server/deployment.yaml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run -it \
+-p 9444:9444 \
+--volume <SOURCE_CONFIGS>/server/deployment.yaml:<TARGET_CONFIGS>/server/deployment.yaml \
+wso2si:4.4.0
+```
+
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2si-4.4.0/conf folder of the container.
+
+## WSO2 Private Docker images
+
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/ubuntu/streaming-integrator/README.md
+++ b/dockerfiles/ubuntu/streaming-integrator/README.md
@@ -1,7 +1,7 @@
-# Dockerfile for WSO2 Streaming Integrator
+# Dockerfile for WSO2 Integrator: SI
 
 This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image
-for WSO2 Streaming Integrator 4.4.0.
+for WSO2 Integrator: SI 4.4.0.
 
 ## Prerequisites
 

--- a/dockerfiles/ubuntu/streaming-integrator/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/streaming-integrator/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+# Copyright 2026 WSO2, LLC. (https://www.wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+# volume mounts
+config_volume=${WORKING_DIRECTORY}/wso2-config-volume
+artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+
+# check if the WSO2 non-root user home exists
+test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+# check if the WSO2 product home exists
+test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# copy any configuration changes mounted to config_volume
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+# copy any artifact changes mounted to artifact_volume
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+
+# start WSO2 server
+sh ${WSO2_SERVER_HOME}/bin/server.sh "$@"


### PR DESCRIPTION
## Summary

- Add `Dockerfile`, `docker-entrypoint.sh`, and `README.md` for WSO2 Streaming Integrator 4.4.0 on three base images:
  - Alpine Linux 3.21.3 (Eclipse Temurin JDK 25.0.2+10, musl)
  - Rocky Linux 9.5 (Eclipse Temurin JDK 25.0.2+10, glibc)
  - Ubuntu 24.04 LTS (Eclipse Temurin JDK 25.0.2+10, glibc)
- All images run as non-root user `wso2carbon` (UID/GID 10802)
- Support `wso2-artifact-volume` pattern for deploying Siddhi apps and extensions at container start
- Update `CHANGELOG.md` with v4.4.0.0 entry

## Test plan

- [ ] Build `linux/amd64` image from Alpine Dockerfile with GA distribution URL
- [ ] Image sanity: JDK version, user/group, home directory layout
- [ ] Boot test: SI starts successfully, management port responds
- [ ] Run 18-test smoke suite (CDC #17/#18 excluded — known upstream bug): all pass against Alpine image
- [ ] Rocky Linux and Ubuntu images build and boot successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)